### PR TITLE
Fixed useWindowSize not being reactive

### DIFF
--- a/packages/core/useWindowSize/index.test.ts
+++ b/packages/core/useWindowSize/index.test.ts
@@ -19,4 +19,15 @@ describe('useWindowSize', () => {
     expect(wrapper.vm.width).toBe(window.innerWidth)
     expect(wrapper.vm.height).toBe(window.innerHeight)
   })
+
+  it('sets handler for window "resize" event', () => {
+    const windowAddEventListener = jest.spyOn(window, 'addEventListener');
+
+    renderHook(() => {
+      const { width, height } = useWindowSize(100, 200)
+      return { width, height }
+    })
+
+    expect(windowAddEventListener).toHaveBeenCalledWith('resize', expect.anything(), undefined)
+  })
 })

--- a/packages/core/useWindowSize/index.ts
+++ b/packages/core/useWindowSize/index.ts
@@ -6,7 +6,7 @@ export function useWindowSize (initialWidth = Infinity, initialHeight = Infinity
   const width = ref(isClient ? window.innerWidth : initialWidth)
   const height = ref(isClient ? window.innerHeight : initialHeight)
 
-  if (!isClient) {
+  if (isClient) {
     useEventListener('resize', () => {
       width.value = window.innerWidth
       height.value = window.innerHeight


### PR DESCRIPTION
Fixed `useWindowSize` not being reactive. I believe this mistake have sneaked during recent refactor.

Speaking of testing I couldn't come up with better option then spying on `window.addEventListener`. Let me know if you want that to be added to this PR.

```js
it('sets handler for window "resize" event', () => {
  const windowAddEventListener = jest.spyOn(window, 'addEventListener');

  renderHook(() => {
    const { width, height } = useWindowSize(100, 200)
    return { width, height }
  })

  expect(windowAddEventListener).toHaveBeenCalledWith('resize', expect.anything(), undefined)
})
```