### PR TITLE
Add support for custom transition functions

### DIFF
--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -39,4 +39,4 @@ The following transitions are available out of the box. Check out [easings.net](
 - `easeOutBack`
 - `easeInOutBack`
 
-Custom transitions can be provided as an array of numbers. For example, [`[0.75, 0, 0.25, 1]`](https://cubic-bezier.com/#.75,0,.25,1) would be an ease-in-out transition.
+Custom transitions can be provided as an array of numbers, or a custom function. For example, [`[0.75, 0, 0.25, 1]`](https://cubic-bezier.com/#.75,0,.25,1) would be an ease-in-out transition.

--- a/packages/core/useTransition/index.stories.tsx
+++ b/packages/core/useTransition/index.stories.tsx
@@ -18,7 +18,7 @@ const track = {
   maxWidth: '20rem',
   padding: '0 0.5rem',
   width: '100%',
-};
+}
 
 const sled = {
   background: '#68d391',
@@ -31,15 +31,15 @@ const sled = {
 
 const Demo = defineComponent({
   setup() {
-    const baseNumber = ref(0);
+    const baseNumber = ref(0)
 
     const easeInOutElastic = (x: number) => {
-      const c5 = (2 * Math.PI) / 4.5;
+      const c5 = (2 * Math.PI) / 4.5
       return x === 0
         ? 0 : x === 1
-        ? 1 : x < 0.5
-        ? -(2 ** ( 20 * x - 10) * Math.sin((20 * x - 11.125) * c5)) / 2 : (2 ** (-20 * x + 10) * Math.sin((20 * x - 11.125) * c5)) / 2 + 1;
-    };
+          ? 1 : x < 0.5
+            ? -(2 ** (20 * x - 10) * Math.sin((20 * x - 11.125) * c5)) / 2 : (2 ** (-20 * x + 10) * Math.sin((20 * x - 11.125) * c5)) / 2 + 1
+    }
 
     const cubicBezierNumber = useTransition(baseNumber, {
       duration: 1500,
@@ -63,7 +63,7 @@ const Demo = defineComponent({
     const Docs = <ShowDocs md={require('./index.md')} />
 
     const onClick = () => {
-      this.baseNumber = this.baseNumber === 100 ? 0 : 100;
+      this.baseNumber = this.baseNumber === 100 ? 0 : 100
     }
 
     return (

--- a/packages/core/useTransition/index.stories.tsx
+++ b/packages/core/useTransition/index.stories.tsx
@@ -1,7 +1,7 @@
 import 'vue-tsx-support/enable-check'
 import Vue from 'vue'
 import { storiesOf } from '@storybook/vue'
-import { defineComponent, ref } from '../../api'
+import { computed, defineComponent, ref } from '../../api'
 import { ShowDocs } from '../../_docs/showdocs'
 import { useTransition } from '.'
 
@@ -10,20 +10,51 @@ type Inject = {
   number: number
 }
 
-const rand = () => Math.floor(Math.random() * (1000 - 0) + 0)
+const track = {
+  background: 'rgba(255, 255, 255, 0.15)',
+  borderRadius: '1rem',
+  height: '1rem',
+  margin: '0.5rem',
+  maxWidth: '20rem',
+  padding: '0 0.5rem',
+  width: '100%',
+};
+
+const sled = {
+  background: '#68d391',
+  borderRadius: '50%',
+  height: '1rem',
+  position: 'absolute',
+  transform: 'translateX(-50%)',
+  width: '1rem',
+}
 
 const Demo = defineComponent({
   setup() {
-    const baseNumber = ref(rand())
+    const baseNumber = ref(0);
 
-    const number = useTransition(baseNumber, {
-      duration: 1000,
-      transition: 'easeInOutExpo',
+    const easeInOutElastic = (x: number) => {
+      const c5 = (2 * Math.PI) / 4.5;
+      return x === 0
+        ? 0 : x === 1
+        ? 1 : x < 0.5
+        ? -(2 ** ( 20 * x - 10) * Math.sin((20 * x - 11.125) * c5)) / 2 : (2 ** (-20 * x + 10) * Math.sin((20 * x - 11.125) * c5)) / 2 + 1;
+    };
+
+    const cubicBezierNumber = useTransition(baseNumber, {
+      duration: 1500,
+      transition: [0.75, 0, 0.25, 1],
+    })
+
+    const customFnNumber = useTransition(baseNumber, {
+      duration: 1500,
+      transition: easeInOutElastic,
     })
 
     return {
       baseNumber,
-      number,
+      cubicBezierNumber,
+      customFnNumber,
     }
   },
 
@@ -32,17 +63,37 @@ const Demo = defineComponent({
     const Docs = <ShowDocs md={require('./index.md')} />
 
     const onClick = () => {
-      this.baseNumber = rand()
+      this.baseNumber = this.baseNumber === 100 ? 0 : 100;
     }
 
     return (
       <div>
         <div id='demo'>
-          <button onClick={onClick}>
-            Change number
-          </button>
-          <p>Base number: <b>{this.baseNumber}</b></p>
-          <p>Transitioned number: <b>{Math.round(this.number)}</b></p>
+          <button onClick={onClick}>Transition</button>
+
+          <p style={{ marginTop: '1rem' }}>
+            Base number: <b>{this.baseNumber}</b>
+          </p>
+
+          <p style={{ marginTop: '1rem' }}>
+            Cubic bezier curve: <b>{this.cubicBezierNumber}</b>
+          </p>
+
+          <div style={track}>
+            <div style={{ position: 'relative' }}>
+              <div style={{ ...sled, left: computed(() => `${this.cubicBezierNumber}%`).value }} />
+            </div>
+          </div>
+
+          <p style={{ marginTop: '1rem' }}>
+            Custom function: <b>{this.customFnNumber}</b>
+          </p>
+
+          <div style={track}>
+            <div style={{ position: 'relative' }}>
+              <div style={{ ...sled, left: computed(() => `${this.customFnNumber}%`).value }} />
+            </div>
+          </div>
         </div>
         {Docs}
       </div>

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,6 +1,6 @@
 import { useRafFn } from '../useRafFn'
 import { Ref, ref, watch } from '../../api'
-import { clamp, isString, noop } from '../../utils'
+import { clamp, isFunction, isString, noop } from '../../utils'
 
 type CubicBezier = [number, number, number, number]
 
@@ -8,7 +8,7 @@ type NamedPreset = 'linear' | 'easeInSine' | 'easeOutSine' | 'easeInQuad' | 'eas
 
 type StateEasingOptions = {
   duration?: number
-  transition?: NamedPreset | CubicBezier
+  transition?: (x: number) => number | NamedPreset | CubicBezier
 }
 
 const cubicBezier = ([p0, p1, p2, p3]: CubicBezier) => {
@@ -71,11 +71,13 @@ export function useTransition(baseNumber: Ref<number>, options: StateEasingOptio
     ...options,
   }
 
-  const getValue = cubicBezier(
-    isString(normalizedOptions.transition)
-      ? presets[normalizedOptions.transition as NamedPreset]
-      : normalizedOptions.transition,
-  )
+  const getValue = isFunction(normalizedOptions.transition)
+    ? normalizedOptions.transition
+    : cubicBezier(
+      isString(normalizedOptions.transition)
+        ? presets[normalizedOptions.transition as NamedPreset]
+        : normalizedOptions.transition,
+    )
 
   let stop = noop
 

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -4,14 +4,16 @@ import { clamp, isFunction, isString, noop } from '../../utils'
 
 type CubicBezier = [number, number, number, number]
 
+type EasingFunction = (x: number) => number
+
 type NamedPreset = 'linear' | 'easeInSine' | 'easeOutSine' | 'easeInQuad' | 'easeOutQuad' | 'easeInCubic' | 'easeOutCubic' | 'easeInOutCubic' | 'easeInQuart' | 'easeOutQuart' | 'easeInOutQuart' | 'easeInQuint' | 'easeOutQuint' | 'easeInOutQuint' | 'easeInExpo' | 'easeOutExpo' | 'easeInOutExpo' | 'easeInCirc' | 'easeOutCirc' | 'easeInOutCirc' | 'easeInBack' | 'easeOutBack' | 'easeInOutBack'
 
 type StateEasingOptions = {
   duration?: number
-  transition?: (x: number) => number | NamedPreset | CubicBezier
+  transition?: EasingFunction | NamedPreset | CubicBezier
 }
 
-const cubicBezier = ([p0, p1, p2, p3]: CubicBezier) => {
+const cubicBezier = ([p0, p1, p2, p3]: CubicBezier): EasingFunction => {
   const a = (a1: number, a2: number) => 1 - 3 * a2 + 3 * a1
   const b = (a1: number, a2: number) => 3 * a2 - 6 * a1
   const c = (a1: number) => 3 * a1
@@ -71,7 +73,7 @@ export function useTransition(baseNumber: Ref<number>, options: StateEasingOptio
     ...options,
   }
 
-  const getValue = isFunction(normalizedOptions.transition)
+  const getValue = isFunction<EasingFunction>(normalizedOptions.transition)
     ? normalizedOptions.transition
     : cubicBezier(
       isString(normalizedOptions.transition)

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -5,6 +5,7 @@ export const assert = (condition: boolean, ...infos: any[]) => {
 }
 const toString = Object.prototype.toString
 export const isBoolean = (val: any): val is boolean => typeof val === 'boolean'
+export const isFunction = (val: any): val is Function => typeof val === 'function'
 export const isNumber = (val: any): val is number => typeof val === 'number'
 export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isObject = (val: any): val is object =>

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -5,7 +5,7 @@ export const assert = (condition: boolean, ...infos: any[]) => {
 }
 const toString = Object.prototype.toString
 export const isBoolean = (val: any): val is boolean => typeof val === 'boolean'
-export const isFunction = (val: any): val is Function => typeof val === 'function'
+export const isFunction = <T = Function> (val: any): val is T => typeof val === 'function'
 export const isNumber = (val: any): val is number => typeof val === 'number'
 export const isString = (val: unknown): val is string => typeof val === 'string'
 export const isObject = (val: any): val is object =>


### PR DESCRIPTION
The other day I needed to get a bit fancier with state transitions, this PR allows for custom functions to be provided instead of just cubic bezier curves. I didn't add any presets, but now we're free to specify weird transitions like these 😅 

[![easings](https://user-images.githubusercontent.com/7980426/82950647-7f4f5500-9f5a-11ea-80bf-8f66a4e1c0ae.png)](https://easings.net/#easeInOutElastic)
