### PR TITLE
improve useElementVisibility typing

### DIFF
--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -1,7 +1,7 @@
 import { onMounted, ref, Ref, watch } from '../../api'
 import { useWindowScroll } from '../useWindowScroll'
 
-export function useElementVisibility(element: Ref<Element>) {
+export function useElementVisibility(element: Ref<Element|null|undefined>) {
   const { x, y } = useWindowScroll()
   const elementIsVisible = ref(false)
 


### PR DESCRIPTION
When using template refs, we can run into type errors. This PR makes `useElementVisibility` more tolerant of falsy initial values.

```vue
<template>
  <div ref="root" />
</template>

<script lang="ts">
import { defineComponent, ref } from '@vue/composition-api'
import { useElementVisibility } from '@vueuse/core'

export default defineComponent({
  setup() {
    const root = ref<Element>()
    const isVisible = useElementVisibility(root) // Argument of type 'Ref<Element | undefined>' is not assignable to parameter of type 'Ref<Element>'

    return { isVisible }
  }
})
</script>
```