### PR TITLE
fix: avoid warning - onMounted is called when...

### DIFF
--- a/packages/core/createGlobalState/index.ts
+++ b/packages/core/createGlobalState/index.ts
@@ -3,7 +3,11 @@ import { reactive } from 'vue-demi'
 export function createGlobalState<T extends object>(
   factory: () => T,
 ) {
-  const state = reactive(factory()) as T
+  let state: T
 
-  return () => state
+  return () => {
+    if (!state)
+      state = reactive(factory()) as T
+    return state
+  }
 }


### PR DESCRIPTION
> using createGlobalState and useStorage will cause a warning

![image](https://user-images.githubusercontent.com/6105607/87868585-00aaed00-c9ca-11ea-92ad-9b76c4617f78.png)

` createGlobalState(() => useStorage(''))`   

--> 

`[Vue warn]: onMounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.`


make the `useStorage`( in createGlobalState factory ) executed at the first time to use would avoid this warning.