### PR TITLE
feat: add useIntersectionObserver

### DIFF
--- a/packages/core/useIntersectionObserver/index.md
+++ b/packages/core/useIntersectionObserver/index.md
@@ -34,3 +34,14 @@ export default {
   }
 }
 ```
+
+[IntersectionObserver MDN](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver)
+
+| State       | Type                           | Description                                                                                                 |
+| ----------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| target      | `Ref<Element|null|undefined>`  | An element whose visibility within the root is to be monitored.                                             |
+| onIntersect | `IntersectionObserverCallback` | A function which is called when the percentage of the target element is visible crosses a threshold.        |
+| root        | `Ref<Element|null|undefined>`  | The Element or Document whose bounds are used as the bounding box when testing for intersection.            |
+| rootMargin  | `string`                       | A string which specifies a set of offsets to add to the root's bounding_box when calculating intersections. |
+| threshold   | `number`                       | Either a single number or an array of numbers between 0.0 and 1.0.                                          |
+

--- a/packages/core/useIntersectionObserver/index.md
+++ b/packages/core/useIntersectionObserver/index.md
@@ -1,0 +1,36 @@
+# useIntersectionObserver
+
+> Detects that a target element's visibility.
+
+## Usage
+
+```tsx
+import { ref } from '@vue/composition-api';
+import { useIntersectionObserver } from '@vueuse/core'
+
+export default {
+  setup() {
+    const target = ref(null);
+    const targetIsVisible = ref(false);
+
+    useIntersectionObserver({
+      target: ref,
+      onIntersect: ([{ isIntersecting }], observerElement) => {
+        targetIsVisible.value = isIntersecting
+      },
+    });
+
+    return {
+      target,
+      targetIsVisible,
+    }
+  },
+  render() {
+    return (
+      <div ref="target">
+        <h1>Hello world</h1>
+      </div>
+    )
+  }
+}
+```

--- a/packages/core/useIntersectionObserver/index.stories.tsx
+++ b/packages/core/useIntersectionObserver/index.stories.tsx
@@ -1,57 +1,57 @@
-import "vue-tsx-support/enable-check";
-import Vue from "vue";
-import { storiesOf } from "@storybook/vue";
-import { defineComponent, ref } from "vue-demi";
-import { ShowDocs } from "../../_docs/showdocs";
-import { useIntersectionObserver } from ".";
+import 'vue-tsx-support/enable-check'
+import Vue from 'vue'
+import { storiesOf } from '@storybook/vue'
+import { defineComponent, ref } from 'vue-demi'
+import { ShowDocs } from '../../_docs/showdocs'
+import { useIntersectionObserver } from '.'
 
 type Inject = {
-  demoIsVisible: boolean;
-};
+  demoIsVisible: boolean
+}
 
 const Demo = defineComponent({
   setup() {
-    const root = ref(null);
-    const demo = ref(null);
-    const demoIsVisible = ref(false);
+    const root = ref(null)
+    const demo = ref(null)
+    const demoIsVisible = ref(false)
 
     useIntersectionObserver({
       // root,
       target: demo,
       onIntersect: ([{ isIntersecting }], observerElement) => {
         // console.log(observerElement);
-        demoIsVisible.value = isIntersecting;
+        demoIsVisible.value = isIntersecting
       },
-    });
+    })
 
     return {
       root,
       demo,
       demoIsVisible,
-    };
+    }
   },
   render(this: Vue & Inject) {
     // @ts-ignore
-    const Docs = <ShowDocs md={require("./index.md")} />;
+    const Docs = <ShowDocs md={require('./index.md')} />
 
     return (
       <div>
         <div
           style={{
-            border: "2px dashed #ccc",
-            maxHeight: "100px",
-            margin: "6rem 2rem",
-            overflowY: "scroll",
+            border: '2px dashed #ccc',
+            maxHeight: '100px',
+            margin: '6rem 2rem',
+            overflowY: 'scroll',
           }}
           ref="root"
         >
-          <p style={{ textAlign: "center" }}>Scroll!</p>
+          <p style={{ textAlign: 'center' }}>Scroll!</p>
           <div
             style={{
-              border: "2px dashed #d78a8a",
-              minHeight: "200px",
-              margin: "10rem 2rem",
-              padding: "1rem",
+              border: '2px dashed #d78a8a',
+              minHeight: '200px',
+              margin: '10rem 2rem',
+              padding: '1rem',
             }}
             ref="demo"
           >
@@ -62,17 +62,17 @@ const Demo = defineComponent({
         <div
           id="demo"
           style={{
-            position: "fixed",
+            position: 'fixed',
             bottom: 0,
             right: 0,
-            padding: "1em 5em 1em 1.5em",
+            padding: '1em 5em 1em 1.5em',
           }}
         >
-          {this.demoIsVisible ? "In the viewport" : "Outside the viewport"}
+          {this.demoIsVisible ? 'In the viewport' : 'Outside the viewport'}
         </div>
       </div>
-    );
+    )
   },
-});
+})
 
-storiesOf("Sensors", module).add("useIntersectionObserver", () => Demo as any);
+storiesOf('Sensors', module).add('useIntersectionObserver', () => Demo as any)

--- a/packages/core/useIntersectionObserver/index.stories.tsx
+++ b/packages/core/useIntersectionObserver/index.stories.tsx
@@ -1,0 +1,78 @@
+import "vue-tsx-support/enable-check";
+import Vue from "vue";
+import { storiesOf } from "@storybook/vue";
+import { defineComponent, ref } from "vue-demi";
+import { ShowDocs } from "../../_docs/showdocs";
+import { useIntersectionObserver } from ".";
+
+type Inject = {
+  demoIsVisible: boolean;
+};
+
+const Demo = defineComponent({
+  setup() {
+    const root = ref(null);
+    const demo = ref(null);
+    const demoIsVisible = ref(false);
+
+    useIntersectionObserver({
+      // root,
+      target: demo,
+      onIntersect: ([{ isIntersecting }], observerElement) => {
+        // console.log(observerElement);
+        demoIsVisible.value = isIntersecting;
+      },
+    });
+
+    return {
+      root,
+      demo,
+      demoIsVisible,
+    };
+  },
+  render(this: Vue & Inject) {
+    // @ts-ignore
+    const Docs = <ShowDocs md={require("./index.md")} />;
+
+    return (
+      <div>
+        <div
+          style={{
+            border: "2px dashed #ccc",
+            maxHeight: "100px",
+            margin: "6rem 2rem",
+            overflowY: "scroll",
+          }}
+          ref="root"
+        >
+          <p style={{ textAlign: "center" }}>Scroll!</p>
+          <div
+            style={{
+              border: "2px dashed #d78a8a",
+              minHeight: "200px",
+              margin: "10rem 2rem",
+              padding: "1rem",
+            }}
+            ref="demo"
+          >
+            <h1>Hello world</h1>
+          </div>
+        </div>
+        {Docs}
+        <div
+          id="demo"
+          style={{
+            position: "fixed",
+            bottom: 0,
+            right: 0,
+            padding: "1em 5em 1em 1.5em",
+          }}
+        >
+          {this.demoIsVisible ? "In the viewport" : "Outside the viewport"}
+        </div>
+      </div>
+    );
+  },
+});
+
+storiesOf("Sensors", module).add("useIntersectionObserver", () => Demo as any);

--- a/packages/core/useIntersectionObserver/index.ts
+++ b/packages/core/useIntersectionObserver/index.ts
@@ -1,0 +1,35 @@
+import { Ref, watchEffect } from 'vue-demi'
+
+interface IntersectionObserverProps {
+  target: Ref<Element|null|undefined>
+  onIntersect: IntersectionObserverCallback
+  root?: Ref<Element|null|undefined>
+  rootMargin?: string
+  threshold?: number
+}
+
+export function useIntersectionObserver({
+  target,
+  onIntersect,
+  root,
+  rootMargin = '0px',
+  threshold = 0.1,
+}: IntersectionObserverProps) {
+  const stopObserver = watchEffect(() => {
+    const observer = new IntersectionObserver(onIntersect, {
+      root: root?.value,
+      rootMargin,
+      threshold,
+    })
+
+    const current = target.value
+
+    current && observer.observe(current)
+
+    return () => {
+      current && observer.unobserve(current)
+    }
+  })
+
+  return stopObserver
+}


### PR DESCRIPTION
新增 IntersectionObserver Hook
用于检测 【目标元素】 于 【根元素】 内是否曝光

用途：图片懒加载、商品曝光率检测