### PR TITLE
feat: add asyncComputed

### DIFF
--- a/packages/core/asyncComputed/index.md
+++ b/packages/core/asyncComputed/index.md
@@ -1,0 +1,41 @@
+# asyncComputed
+
+> Like [computed refs](https://composition-api.vuejs.org/api.html#computed), but with support for promises.
+
+## Usage
+
+```jsx
+import { ref } from 'vue-demi'
+import { asyncComputed } from '@vueuse/core'
+
+export default {
+  template: `<p>
+    Package: <input v-model="packageName"><br>
+    Weekly Downloads: {{ isFetchingDownloads ? 'fetching...' : downloads }}
+  </p>`,
+  setup() {
+    const packageName = ref('vueuse')
+    const [downloads, isFetchingDownloads] = asyncComputed((onCancel) => {
+      const abortController = new AbortController()
+
+      onCancel(() => {
+        abortController.abort()
+      })
+
+      return fetch(`https://api.npmjs.org/downloads/point/last-week/${packageName.value}`, {
+        signal: abortController.signal,
+      })
+        .then(response => response.json())
+        .then(result => result.downloads)
+    })
+
+    return { packageName, downloads, isFetchingDownloads }
+  },
+}
+```
+
+## Caveats
+- Just like Vue's built-in `computed` function, `useAsyncComputed` does dependency tracking and is automatically re-evaluated when dependencies change.
+
+  Note however that only dependencies referenced in the first call stack are considered for this. In other words: Dependencies which are accessed asynchronously are not triggering re-evaluation of the async computed value.
+- As opposed to Vue's built-in `computed` function, re-evaluation of the async computed value is triggered whenever dependencies are changing, regardless whether its result is currently being tracked or not.

--- a/packages/core/asyncComputed/index.stories.tsx
+++ b/packages/core/asyncComputed/index.stories.tsx
@@ -1,0 +1,58 @@
+import 'vue-tsx-support/enable-check'
+import Vue from 'vue'
+import { storiesOf } from '@storybook/vue'
+import { ref, defineComponent } from 'vue-demi'
+import { ShowDocs } from '../../_docs/showdocs'
+import { asyncComputed } from '.'
+
+type Inject = {
+  packageName: string
+  downloads: number
+  isFetchingDownloads: boolean
+}
+
+const Demo = defineComponent({
+  setup(_props) {
+    const packageName = ref('@vueuse/core')
+
+    const [downloads, isFetchingDownloads] = asyncComputed((onCancel) => {
+      const abortController = new AbortController()
+
+      onCancel(() => {
+        abortController.abort()
+      })
+
+      return fetch(`https://api.npmjs.org/downloads/point/last-week/${packageName.value}`, {
+        signal: abortController.signal,
+      })
+        .then(response => response.ok ? response.json() : { downloads: '—' })
+        .then(result => result.downloads)
+    }, 0)
+
+    return { packageName, downloads, isFetchingDownloads }
+  },
+
+  render(this: Vue & Inject) {
+    const { packageName, downloads, isFetchingDownloads } = this
+
+    // @ts-ignore
+    const Docs = <ShowDocs md={require('./index.md')}/>
+
+    return (
+      <div>
+        <div id="demo">
+          <p>
+            npm Package: <input value={packageName} onChange={($event) => {
+              this.packageName = $event.currentTarget.value
+            }} /><br />
+            Weekly Downloads: {isFetchingDownloads ? '...' : downloads}
+          </p>
+        </div>
+        {Docs}
+      </div>
+    )
+  },
+})
+
+storiesOf('State', module)
+  .add('asyncComputed', () => Demo as any)

--- a/packages/core/asyncComputed/index.ts
+++ b/packages/core/asyncComputed/index.ts
@@ -1,0 +1,57 @@
+import { ref, watchEffect, Ref } from 'vue-demi'
+
+/**
+ * Handle overlapping async evaluations
+ *
+ * @param cancelCallback The provided callback is invoked when a re-evaluation of the computed value is triggered before the previous one finished
+ */
+export type AsyncComputedOnCancel = (cancelCallback: () => void) => void
+
+/**
+ * A two-item tuple with the first item being a ref to the computed value and the second item holding a boolean ref, indicating whether the async computed value is currently (re-)evaluated
+ */
+export type AsyncComputedResult<T> = [Ref<T>, Ref<boolean>]
+
+/**
+ * Create an asynchronous computed dependency
+ *
+ * @param evaluationCallback     The promise-returning callback which generates the computed value
+ * @param defaultValue           A default value, used until the first evaluation finishes
+ */
+export function asyncComputed<T>(
+  evaluationCallback: (onCancel: AsyncComputedOnCancel) => T | Promise<T>,
+  defaultValue?: T,
+): AsyncComputedResult<T> {
+  let counter = 0
+  const current = ref(defaultValue) as Ref<T>
+  const evaluating = ref<boolean>(false)
+
+  watchEffect(async(onInvalidate) => {
+    counter++
+    const counterAtBeginning = counter
+    let hasFinished = false
+
+    try {
+      // Defer initial setting of `evaluating` ref
+      // to avoid having it as a dependency
+      Promise.resolve().then(() => {
+        evaluating.value = true
+      })
+
+      const result = await evaluationCallback((cancelCallback) => {
+        onInvalidate(() => {
+          evaluating.value = false
+          if (!hasFinished) cancelCallback()
+        })
+      })
+
+      if (counterAtBeginning === counter) current.value = result
+    }
+    finally {
+      evaluating.value = false
+      hasFinished = true
+    }
+  })
+
+  return [current, evaluating]
+}


### PR DESCRIPTION
Okay, this took me quite a while. Mostly due to Storybook — I had to locally downgrade PostCSS to v7 because of an incompatibility between PostCSS 8 and Tailwind — but also due to tests. I haven't added any of those, even though I would've loved to, but I'd need refs for tests and `vue-demi` smacks me with "No vue dependency found" errors. Ideas?

(Resolves #128)