### PR TITLE
fix: rollup typescript config overwrite

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,9 +51,9 @@ for (const [pkg, options] of packages) {
       typescript({
         tsconfig: path.resolve(__dirname, 'tsconfig.rollup.json'),
         tsconfigOverride: {
-          declaration: false,
-          declarationDir: null,
-          declarationMap: false,
+          compilerOptions: {
+            declaration: false,
+          },
         },
       }),
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@
 import typescript from 'rollup-plugin-typescript2'
 import { uglify } from 'rollup-plugin-uglify'
 import dts from 'rollup-plugin-dts'
-import path from 'path'
 
 const packages = require('./scripts/packages')
 const configs = []
@@ -49,7 +48,6 @@ for (const [pkg, options] of packages) {
     ],
     plugins: [
       typescript({
-        tsconfig: path.resolve(__dirname, 'tsconfig.rollup.json'),
         tsconfigOverride: {
           compilerOptions: {
             declaration: false,

--- a/tsconfig.rollup.json
+++ b/tsconfig.rollup.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "declaration": false,
-  }
-}


### PR DESCRIPTION
1. Change usage of `rollup-plugin-typescript2` opts.tsconfigOverride
2. Remove unnecessary `tsconfig.rollup.json`