### PR TITLE
refactor!: API changes in useRefHistory (capacity, prev, next)

### DIFF
--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -6,19 +6,19 @@
 
 ```ts
 import { ref } from 'vue' 
-import { useRefHistory, undo, redo, clear } from '@vueuse/core'
+import { useRefHistory } from '@vueuse/core'
 
 const counter = ref(0)
-const { history, undo, redo } = useRefHistory(counter, {
+const { prev, undo, redo } = useRefHistory(counter, {
   deep: false,
   clone: true,
-  limit: 15, // limit to n history records, default to unlimited
+  capacity: 15, // limit to n history records, default to unlimited
 })
 
 counter.value += 1
 counter.value = 10
 
-console.log(history) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
+console.log(prev) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
 
 console.log(counter.value) // 10
 undo()

--- a/packages/core/useRefHistory/index.stories.tsx
+++ b/packages/core/useRefHistory/index.stories.tsx
@@ -19,7 +19,7 @@ defineDemo(
       return {
         ...counter,
         ...useRefHistory(counter.count, {
-          limit: 10,
+          capacity: 10,
         }),
         format,
       }
@@ -31,8 +31,8 @@ defineDemo(
         <button @click="inc()">Increment</button>
         <button @click="dec()">Decrement</button>
         <span class="mx-2">/</span>
-        <button @click="undo()" :disabled='!history.length'>Undo</button>
-        <button @click="redo()" :disabled='!redoHistory.length'>Redo</button>
+        <button @click="undo()" :disabled='!prev.length'>Undo</button>
+        <button @click="redo()" :disabled='!next.length'>Redo</button>
         <br>
         <note>History (limited to 10 records)</note>
         <div class="ml-2">

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -6,30 +6,30 @@ describe('useRefHistory', () => {
   test('should record', () => {
     renderHook(() => {
       const v = ref(0)
-      const { history } = useRefHistory(v)
+      const { prev } = useRefHistory(v)
 
-      expect(history.length).toBe(1)
-      expect(history[0].value).toBe(0)
+      expect(prev.length).toBe(1)
+      expect(prev[0].value).toBe(0)
 
       v.value = 2
 
-      expect(history.length).toBe(2)
-      expect(history[0].value).toBe(2)
-      expect(history[1].value).toBe(0)
+      expect(prev.length).toBe(2)
+      expect(prev[0].value).toBe(2)
+      expect(prev[1].value).toBe(0)
     })
   })
 
   test('should be able to undo and redo', () => {
     renderHook(() => {
       const v = ref(0)
-      const { undo, redo, history } = useRefHistory(v)
+      const { undo, redo, prev } = useRefHistory(v)
 
       v.value = 2
       v.value = 3
       v.value = 4
 
       expect(v.value).toBe(4)
-      expect(history.length).toBe(4)
+      expect(prev.length).toBe(4)
       undo()
       expect(v.value).toBe(3)
       undo()


### PR DESCRIPTION
Changed limit to capacity, history to prev and redoHistory to next, as discussed in point 2 of https://github.com/antfu/vueuse/issues/137

```
        <button @click="undo()" :disabled='!prev.length'>Undo</button>
        <button @click="redo()" :disabled='!next.length'>Redo</button>