### PR TITLE
refactor!: useRefHistory api improves

### DIFF
--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -9,7 +9,7 @@ import { ref } from 'vue'
 import { useRefHistory } from '@vueuse/core'
 
 const counter = ref(0)
-const { prev, undo, redo } = useRefHistory(counter, {
+const { history, undo, redo } = useRefHistory(counter, {
   deep: false,
   clone: false,
   capacity: 15, // limit to n history records, default to unlimited
@@ -18,7 +18,7 @@ const { prev, undo, redo } = useRefHistory(counter, {
 counter.value += 1
 counter.value = 10
 
-console.log(prev) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
+console.log(history) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
 
 console.log(counter.value) // 10
 undo()

--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -23,7 +23,7 @@ console.log(counter.value) // 1
 
 ### Objects / arrays
 
-When working with objects or arrays, since changing their attributes does not change it's reference, all the value in the history will point to a same reference. If you want to keep the state changes, you would need to pass `clone: true`. It will create clones for each history records.
+When working with objects or arrays, since changing their attributes does not change the reference, it will not trigger the committing. To track attribute changes, you would need to pass `deep: true`. It will create clones for each history record.
 
 ```ts
 const state = ref({
@@ -33,7 +33,6 @@ const state = ref({
 
 const { history, undo, redo } = useRefHistory(state, {
   deep: true,
-  clone: true,
 })
 
 state.value.foo = 2
@@ -45,12 +44,35 @@ console.log(history.value)
 ] */
 ```
 
-### History Capcity
+#### Custom Clone Function
+
+`useRefHistory` only embeds the minimal clone function `x => JSON.parse(JSON.stringify(x))`. To use a full featured or custom clone function, you can set up via the `dump` options.
+
+For example, using [lodash's `cloneDeep`](https://lodash.com/docs/4.17.15#cloneDeep):
+
+```ts
+import { cloneDeep } from 'lodash-es'
+import { useRefHistory } from '@vueuse/core'
+
+const refHistory = useRefHistory(target, { dump: cloneDeep })
+```
+
+Or a more lightweight [`klona`](https://github.com/lukeed/klona):
+
+```ts
+import { klona } from 'klona'
+import { useRefHistory } from '@vueuse/core'
+
+const refHistory = useRefHistory(target, { dump: klona })
+```
+
+
+### History Capacity
 
 We will keep all the history by default (unlimited) until you explicitly clean them up, you can set the maximal amount of history to be kept by `capacity` options.
 
 ```ts
-const refHistory = useRefHistory(ref, {
+const refHistory = useRefHistory(target, {
   capacity: 15 // limit to 15 history records
 })
 

--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -9,18 +9,50 @@ import { ref } from 'vue'
 import { useRefHistory } from '@vueuse/core'
 
 const counter = ref(0)
-const { history, undo, redo } = useRefHistory(counter, {
-  deep: false,
-  clone: false,
-  capacity: 15, // limit to n history records, default to unlimited
-})
+const { history, undo, redo } = useRefHistory(counter)
 
 counter.value += 1
 counter.value = 10
 
-console.log(history) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
+console.log(history.value) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
 
 console.log(counter.value) // 10
 undo()
 console.log(counter.value) // 1 
+```
+
+### Objects / arrays
+
+When working with objects or arrays, since changing their attributes does not change it's reference, all the value in the history will point to a same reference. If you want to keep the state changes, you would need to pass `clone: true`. It will create clones for each history records.
+
+```ts
+const state = ref({
+  foo: 1,
+  bar: 'bar'
+})
+
+const { history, undo, redo } = useRefHistory(state, {
+  deep: true,
+  clone: true,
+})
+
+state.value.foo = 2
+
+console.log(history.value) 
+/* [
+  { value: { foo: 2, bar: 'bar' } },
+  { value: { foo: 1, bar: 'bar' } }
+] */
+```
+
+### History Capcity
+
+We will keep all the history by default (unlimited) until you explicitly clean them up, you can set the maximal amount of history to be kept by `capacity` options.
+
+```ts
+const refHistory = useRefHistory(ref, {
+  capacity: 15 // limit to 15 history records
+})
+
+refHistory.clean() // explicitly clean all the history
 ```

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -6,30 +6,30 @@ describe('useRefHistory', () => {
   test('should record', () => {
     renderHook(() => {
       const v = ref(0)
-      const { prev } = useRefHistory(v)
+      const { history } = useRefHistory(v)
 
-      expect(prev.length).toBe(1)
-      expect(prev[0].value).toBe(0)
+      expect(history.length).toBe(1)
+      expect(history[0].value).toBe(0)
 
       v.value = 2
 
-      expect(prev.length).toBe(2)
-      expect(prev[0].value).toBe(2)
-      expect(prev[1].value).toBe(0)
+      expect(history.length).toBe(2)
+      expect(history[0].value).toBe(2)
+      expect(history[1].value).toBe(0)
     })
   })
 
   test('should be able to undo and redo', () => {
     renderHook(() => {
       const v = ref(0)
-      const { undo, redo, prev } = useRefHistory(v)
+      const { undo, redo, history } = useRefHistory(v)
 
       v.value = 2
       v.value = 3
       v.value = 4
 
       expect(v.value).toBe(4)
-      expect(prev.length).toBe(4)
+      expect(history.length).toBe(4)
       undo()
       expect(v.value).toBe(3)
       undo()
@@ -46,59 +46,59 @@ describe('useRefHistory', () => {
   test('object', () => {
     renderHook(() => {
       const v = ref({ foo: 'bar' })
-      const { prev } = useRefHistory(v, { deep: true })
+      const { history } = useRefHistory(v, { deep: true })
 
-      expect(prev.length).toBe(1)
-      expect(prev[0].value.foo).toBe('bar')
+      expect(history.length).toBe(1)
+      expect(history[0].value.foo).toBe('bar')
 
       v.value.foo = 'foo'
 
-      expect(prev.length).toBe(2)
-      expect(prev[0].value.foo).toBe('foo')
+      expect(history.length).toBe(2)
+      expect(history[0].value.foo).toBe('foo')
 
       // same reference
-      expect(prev[1].value.foo).toBe('foo')
-      expect(prev[0].value).toBe(prev[1].value)
+      expect(history[1].value.foo).toBe('foo')
+      expect(history[0].value).toBe(history[1].value)
     })
   })
 
   test('object with clone', () => {
     renderHook(() => {
       const v = ref({ foo: 'bar' })
-      const { prev } = useRefHistory(v, { deep: true, clone: true })
+      const { history } = useRefHistory(v, { deep: true, clone: true })
 
-      expect(prev.length).toBe(1)
-      expect(prev[0].value.foo).toBe('bar')
+      expect(history.length).toBe(1)
+      expect(history[0].value.foo).toBe('bar')
 
       v.value.foo = 'foo'
 
-      expect(prev.length).toBe(2)
-      expect(prev[0].value.foo).toBe('foo')
+      expect(history.length).toBe(2)
+      expect(history[0].value.foo).toBe('foo')
 
       // different references
-      expect(prev[1].value.foo).toBe('bar')
-      expect(prev[0].value).not.toBe(prev[1].value)
+      expect(history[1].value.foo).toBe('bar')
+      expect(history[0].value).not.toBe(history[1].value)
     })
   })
 
   test('dump + parse', () => {
     renderHook(() => {
       const v = ref({ a: 'bar' })
-      const { prev, undo } = useRefHistory(v, {
+      const { history, undo } = useRefHistory(v, {
         deep: true,
         clone: true,
         dump: v => JSON.stringify(v),
         parse: (v: string) => JSON.parse(v),
       })
 
-      expect(prev.length).toBe(1)
-      expect(prev[0].value).toBe('{"a":"bar"}')
+      expect(history.length).toBe(1)
+      expect(history[0].value).toBe('{"a":"bar"}')
 
       v.value.a = 'foo'
 
-      expect(prev.length).toBe(2)
-      expect(prev[0].value).toBe('{"a":"foo"}')
-      expect(prev[1].value).toBe('{"a":"bar"}')
+      expect(history.length).toBe(2)
+      expect(history[0].value).toBe('{"a":"foo"}')
+      expect(history[1].value).toBe('{"a":"bar"}')
 
       undo()
 

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -43,29 +43,10 @@ describe('useRefHistory', () => {
     })
   })
 
-  test('object', () => {
+  test('object with deep', () => {
     renderHook(() => {
       const v = ref({ foo: 'bar' })
       const { history } = useRefHistory(v, { deep: true })
-
-      expect(history.value.length).toBe(1)
-      expect(history.value[0].value.foo).toBe('bar')
-
-      v.value.foo = 'foo'
-
-      expect(history.value.length).toBe(2)
-      expect(history.value[0].value.foo).toBe('foo')
-
-      // same reference
-      expect(history.value[1].value.foo).toBe('foo')
-      expect(history.value[0].value).toBe(history.value[1].value)
-    })
-  })
-
-  test('object with clone', () => {
-    renderHook(() => {
-      const v = ref({ foo: 'bar' })
-      const { history } = useRefHistory(v, { deep: true, clone: true })
 
       expect(history.value.length).toBe(1)
       expect(history.value[0].value.foo).toBe('bar')
@@ -86,7 +67,6 @@ describe('useRefHistory', () => {
       const v = ref({ a: 'bar' })
       const { history, undo } = useRefHistory(v, {
         deep: true,
-        clone: true,
         dump: v => JSON.stringify(v),
         parse: (v: string) => JSON.parse(v),
       })
@@ -122,7 +102,7 @@ describe('useRefHistory', () => {
 
   test('without batch', () => {
     const v = ref({ foo: 1, bar: 'one' })
-    const { history } = useRefHistory(v, { deep: true, clone: true })
+    const { history } = useRefHistory(v, { deep: true })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toEqual({ foo: 1, bar: 'one' })
@@ -138,7 +118,7 @@ describe('useRefHistory', () => {
 
   test('with batch', () => {
     const v = ref({ foo: 1, bar: 'one' })
-    const { history, batch } = useRefHistory(v, { deep: true, clone: true })
+    const { history, batch } = useRefHistory(v, { deep: true })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toEqual({ foo: 1, bar: 'one' })

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -8,14 +8,14 @@ describe('useRefHistory', () => {
       const v = ref(0)
       const { history } = useRefHistory(v)
 
-      expect(history.length).toBe(1)
-      expect(history[0].value).toBe(0)
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].value).toBe(0)
 
       v.value = 2
 
-      expect(history.length).toBe(2)
-      expect(history[0].value).toBe(2)
-      expect(history[1].value).toBe(0)
+      expect(history.value.length).toBe(2)
+      expect(history.value[0].value).toBe(2)
+      expect(history.value[1].value).toBe(0)
     })
   })
 
@@ -29,7 +29,7 @@ describe('useRefHistory', () => {
       v.value = 4
 
       expect(v.value).toBe(4)
-      expect(history.length).toBe(4)
+      expect(history.value.length).toBe(4)
       undo()
       expect(v.value).toBe(3)
       undo()
@@ -48,17 +48,17 @@ describe('useRefHistory', () => {
       const v = ref({ foo: 'bar' })
       const { history } = useRefHistory(v, { deep: true })
 
-      expect(history.length).toBe(1)
-      expect(history[0].value.foo).toBe('bar')
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].value.foo).toBe('bar')
 
       v.value.foo = 'foo'
 
-      expect(history.length).toBe(2)
-      expect(history[0].value.foo).toBe('foo')
+      expect(history.value.length).toBe(2)
+      expect(history.value[0].value.foo).toBe('foo')
 
       // same reference
-      expect(history[1].value.foo).toBe('foo')
-      expect(history[0].value).toBe(history[1].value)
+      expect(history.value[1].value.foo).toBe('foo')
+      expect(history.value[0].value).toBe(history.value[1].value)
     })
   })
 
@@ -67,17 +67,17 @@ describe('useRefHistory', () => {
       const v = ref({ foo: 'bar' })
       const { history } = useRefHistory(v, { deep: true, clone: true })
 
-      expect(history.length).toBe(1)
-      expect(history[0].value.foo).toBe('bar')
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].value.foo).toBe('bar')
 
       v.value.foo = 'foo'
 
-      expect(history.length).toBe(2)
-      expect(history[0].value.foo).toBe('foo')
+      expect(history.value.length).toBe(2)
+      expect(history.value[0].value.foo).toBe('foo')
 
       // different references
-      expect(history[1].value.foo).toBe('bar')
-      expect(history[0].value).not.toBe(history[1].value)
+      expect(history.value[1].value.foo).toBe('bar')
+      expect(history.value[0].value).not.toBe(history.value[1].value)
     })
   })
 
@@ -91,18 +91,87 @@ describe('useRefHistory', () => {
         parse: (v: string) => JSON.parse(v),
       })
 
-      expect(history.length).toBe(1)
-      expect(history[0].value).toBe('{"a":"bar"}')
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].value).toBe('{"a":"bar"}')
 
       v.value.a = 'foo'
 
-      expect(history.length).toBe(2)
-      expect(history[0].value).toBe('{"a":"foo"}')
-      expect(history[1].value).toBe('{"a":"bar"}')
+      expect(history.value.length).toBe(2)
+      expect(history.value[0].value).toBe('{"a":"foo"}')
+      expect(history.value[1].value).toBe('{"a":"bar"}')
 
       undo()
 
       expect(v.value.a).toBe('bar')
     })
+  })
+
+  test('commit', () => {
+    const v = ref(0)
+    const { commit, history } = useRefHistory(v)
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toBe(0)
+
+    commit()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe(0)
+    expect(history.value[1].value).toBe(0)
+  })
+
+  test('without batch', () => {
+    const v = ref({ foo: 1, bar: 'one' })
+    const { history } = useRefHistory(v, { deep: true, clone: true })
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toEqual({ foo: 1, bar: 'one' })
+
+    v.value.foo = 2
+    v.value.bar = 'two'
+
+    expect(history.value.length).toBe(3)
+    expect(history.value[0].value).toEqual({ foo: 2, bar: 'two' })
+    expect(history.value[1].value).toEqual({ foo: 2, bar: 'one' })
+    expect(history.value[2].value).toEqual({ foo: 1, bar: 'one' })
+  })
+
+  test('with batch', () => {
+    const v = ref({ foo: 1, bar: 'one' })
+    const { history, batch } = useRefHistory(v, { deep: true, clone: true })
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toEqual({ foo: 1, bar: 'one' })
+
+    batch(() => {
+      v.value.foo = 2
+      v.value.bar = 'two'
+    })
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toEqual({ foo: 2, bar: 'two' })
+    expect(history.value[1].value).toEqual({ foo: 1, bar: 'one' })
+  })
+
+  test('pause and resume', () => {
+    const v = ref(1)
+    const { history, pause, resume } = useRefHistory(v)
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toBe(1)
+
+    pause()
+    v.value = 2
+
+    expect(history.value.length).toBe(1)
+
+    resume()
+
+    expect(history.value.length).toBe(1)
+
+    v.value = 3
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe(3)
   })
 })

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -9,6 +9,8 @@ export interface UseRefHistoryRecord<T> {
 export interface UseRefHistoryOptions<Raw, Serialized = Raw> {
   /**
    * Watch for deep changes, default to false
+   *
+   * When set to true, it will also create clones for values store in the history
    */
   deep?: boolean
 
@@ -16,11 +18,6 @@ export interface UseRefHistoryOptions<Raw, Serialized = Raw> {
    * Maximum number of history to be kept. Default to unlimited.
    */
   capacity?: number
-
-  /**
-   * Whether to clone the data, default to false. Useful when working with objects.
-   */
-  clone?: boolean
 
   /**
    * Serialize data into the histry
@@ -119,7 +116,7 @@ export function useRefHistory<Raw, Serialized = Raw>(
   const redoStack: Ref<UseRefHistoryRecord<Serialized>[]> = ref([])
   const tracking = ref(true)
 
-  const _dump = options.dump || (options.clone ? fnClone : fnBypass)
+  const _dump = options.dump || (options.deep ? fnClone : fnBypass)
   const _parse = options.parse || fnBypass
 
   const commit = () => {

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -32,35 +32,113 @@ export interface UseRefHistoryOptions<Raw, Serialized = Raw> {
   parse?: (v: Serialized) => Raw
 }
 
+export interface UseRefHistoryReturn<Raw, Serialized> {
+  /**
+   * Bypassed tracking ref from the argument
+   */
+  current: Ref<Raw>
+
+  /**
+   * An array of history records for undo
+   */
+  history: UseRefHistoryRecord<Serialized>[]
+
+  /**
+   * Same as 'history'
+   */
+  undoStack: UseRefHistoryRecord<Serialized>[]
+
+  /**
+   * Records array for redo
+   */
+  redoStack: UseRefHistoryRecord<Serialized>[]
+
+  /**
+   * A ref representing if the tracking is enabled
+   */
+  isTracking: Ref<boolean>
+
+  /**
+   * Undo changes
+   */
+  undo(): void
+
+  /**
+   * Redo changes
+   */
+  redo(): void
+
+  /**
+   * Clear all the history
+   */
+  clear(): void
+
+  /**
+   * Pause change tracking
+   */
+  pause(): void
+
+  /**
+   * Resume change tracking
+   *
+   * @param [commit] if true, a history record will be create after resuming
+   */
+  resume(commit?: boolean): void
+
+  /**
+   * Create new a new history record
+   */
+  commit(): void
+
+  /**
+   * Reset ref's value with lastest history
+   */
+  reset(): void
+
+  /**
+   * A sugar for auto pause and auto resuming within a function scope
+   *
+   * @param fn
+   */
+  batch(fn: (cancel: (() => void)) => void): void
+
+  /**
+   * Clear the data and stop the watch
+   */
+  dispose(): void
+}
+
 const fnClone = <F, T>(v: F): T => JSON.parse(JSON.stringify(v))
 const fnBypass = <F, T>(v: F) => v as unknown as T
 
 export function useRefHistory<Raw, Serialized = Raw>(
-  r: Ref<Raw>,
+  current: Ref<Raw>,
   options: UseRefHistoryOptions<Raw, Serialized> = {},
-) {
-  const prev: UseRefHistoryRecord<Serialized>[] = []
-  const next: UseRefHistoryRecord<Serialized>[] = []
+): UseRefHistoryReturn<Raw, Serialized> {
+  const undoStack: UseRefHistoryRecord<Serialized>[] = []
+  const redoStack: UseRefHistoryRecord<Serialized>[] = []
   const tracking = ref(true)
 
-  const dump = options.dump || (options.clone ? fnClone : fnBypass)
-  const parse = options.parse || fnBypass
+  const _dump = options.dump || (options.clone ? fnClone : fnBypass)
+  const _parse = options.parse || fnBypass
 
-  const stop = watch(
-    r,
-    (value) => {
-      if (!tracking.value)
-        return
+  const commit = () => {
+    undoStack.unshift({
+      value: _dump(current.value),
+      timestamp: timestamp(),
+    })
 
-      prev.unshift({
-        value: dump(value),
-        timestamp: timestamp(),
-      })
+    if (options.capacity && undoStack.length > options.capacity)
+      undoStack.splice(options.capacity, Infinity)
+    if (redoStack.length)
+      redoStack.splice(0, redoStack.length)
+  }
 
-      if (options.capacity && prev.length > options.capacity)
-        prev.splice(options.capacity, Infinity)
-      if (next.length)
-        next.splice(0, next.length)
+  const _stop = watch(
+    current,
+    () => {
+      if (tracking.value)
+        commit()
     },
     {
       deep: options.deep,
@@ -69,24 +147,31 @@ export function useRefHistory<Raw, Serialized = Raw>(
     },
   )
 
-  const clear = () => {
-    prev.splice(0, prev.length)
-    next.splice(0, next.length)
+  const pause = () => {
+    tracking.value = false
   }
 
-  const pause = () => (tracking.value = false)
-  const resume = () => (tracking.value = true)
+  const resume = (commitNow?: boolean) => {
+    tracking.value = true
+    if (commitNow)
+      commit()
+  }
+
+  const clear = () => {
+    undoStack.splice(0, undoStack.length)
+    redoStack.splice(0, redoStack.length)
+  }
 
   const undo = () => {
     const previous = tracking.value
     tracking.value = false
 
-    const state = prev.shift()
+    const state = undoStack.shift()
 
     if (state)
-      next.unshift(state)
-    if (prev[0])
-      r.value = parse(prev[0].value)
+      redoStack.unshift(state)
+    if (undoStack[0])
+      current.value = _parse(undoStack[0].value)
 
     tracking.value = previous
   }
@@ -95,25 +180,62 @@ export function useRefHistory<Raw, Serialized = Raw>(
     const previous = tracking.value
     tracking.value = false
 
-    const state = next.shift()
+    const state = redoStack.shift()
 
     if (state) {
-      r.value = parse(state.value)
-      prev.unshift(state)
+      current.value = _parse(state.value)
+      undoStack.unshift(state)
     }
 
     tracking.value = previous
   }
 
+  const reset = () => {
+    const previous = tracking.value
+    tracking.value = false
+
+    const state = redoStack[0]
+    if (state)
+      current.value = _parse(state.value)
+
+    tracking.value = previous
+  }
+
+  const batch = (fn: (cancel: () => void) => void) => {
+    const previous = tracking.value
+    tracking.value = false
+    let canceled = false
+
+    const cancel = () => canceled = true
+
+    fn(cancel)
+
+    tracking.value = previous
+
+    if (!canceled)
+      commit()
+  }
+
+  const dispose = () => {
+    _stop()
+    clear()
+  }
+
   return {
-    prev,
-    next,
-    tracking,
+    current,
+    undoStack,
+    redoStack,
+    history: undoStack,
+    isTracking: tracking,
+
     clear,
-    stop,
     pause,
     resume,
+    commit,
+    reset,
+    batch,
     undo,
     redo,
+    dispose,
   }
 }


### PR DESCRIPTION
close #137 

Changed `next` and `prev` to `undoStack` and `redoStack`, also providing an alias `history`