### PR TITLE
Simplify code contributions via online automated dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: yarn install && yarn build
+    command: yarn dev
+ports:
+  - port: 6006
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <a href="https://github.com/antfu/vueuse/issues" target="__blank"><img src="https://img.shields.io/github/issues/antfu/vueuse.svg?color=c977be" alt="GitHub issues" /></a>
 <a href="https://github.com/antfu/vueuse" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/antfu/vueuse?style=social"></a>
 </p>
+<a href="https://gitpod.io/from-referrer/"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"/></a>
 
 <p align="center">
 Collection of essential Vue Composition API (inspired by <a href='https://github.com/streamich/react-use' target='__blank'>react-use</a>)

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -22,6 +22,12 @@ We use Storybook for rapid development and documenting. You can start it locally
 yarn dev
 ```
 
+## Online one-click setup
+
+You can use Gitpod(an online IDE which is free for Open Source) for contributing. With a single click it will launch a workspace and automatically clone the `VueUse` repo, run `yarn install` and `yarn dev`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Contributing to existing functions
 
 Feel free to enhance the existing functions. Please try not to introduce breaking changes.


### PR DESCRIPTION

Hi. I work for Gitpod(an online IDE which is free for Open Source) and we are currently on a mission to simplify contributors onboarding experience for cool and popular Open Source projects by automating their dev setups this can be helpful for newcomers/beginners i.e the can start in just a single click without having to set anything up.

This Pr adds Gitpod config to the repo via which, anyone would be able to launch a workspace where it will automatically:

- clone the `VueUse` repo.
- install the dependencies.
- run `yarn dev` to start the server.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/vueuse

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96332493-b1826000-107d-11eb-91b3-563538fa3a04.png)
