### PR TITLE
BREAKING CHANGE: refactor!(useEventListener): move custom event target argument to first

### DIFF
--- a/packages/core/onStartTyping/index.ts
+++ b/packages/core/onStartTyping/index.ts
@@ -50,5 +50,5 @@ export function onStartTyping(callback: (event: KeyboardEvent) => void) {
       && callback(event)
   }
 
-  useEventListener('keydown', keydown, undefined, document)
+  useEventListener(document, 'keydown', keydown, undefined)
 }

--- a/packages/core/useBattery/index.ts
+++ b/packages/core/useBattery/index.ts
@@ -38,7 +38,7 @@ export function useBattery() {
         battery = _battery
         updateBatteryInfo.call(battery)
         for (const event of events)
-          useEventListener(event, updateBatteryInfo, undefined, battery)
+          useEventListener(battery, event, updateBatteryInfo, undefined)
       })
   }
 

--- a/packages/core/useBrowserLocation/index.ts
+++ b/packages/core/useBrowserLocation/index.ts
@@ -43,8 +43,6 @@ export function useBrowserLocation() {
   const state = ref(buildState('load'))
 
   useEventListener('popstate', () => state.value = buildState('popstate'))
-  useEventListener('pushstate', () => state.value = buildState('pushstate'))
-  useEventListener('replacestate', () => state.value = buildState('replacestate'))
 
   return state
 }

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -1,13 +1,13 @@
 /* this implementation is original ported from https://github.com/logaretm/vue-use-web by Abdelrahman Awad */
 
 import { ref } from 'vue-demi'
-import { useEventListener } from '../useEventListener'
+import { useEventListener, WindowEventName } from '../useEventListener'
 
 export function useClipboard() {
   const text = ref('')
   const supported = ref('clipboard' in window.navigator)
 
-  useEventListener('copy', () => {
+  useEventListener('copy' as WindowEventName, () => {
     window.navigator.clipboard.readText().then((value) => {
       text.value = value
     })

--- a/packages/core/useDocumentVisibility/index.ts
+++ b/packages/core/useDocumentVisibility/index.ts
@@ -4,9 +4,9 @@ import { useEventListener } from '../useEventListener'
 export function useDocumentVisibility() {
   const visibility = ref(document.visibilityState)
 
-  useEventListener('visibilitychange', () => {
+  useEventListener(document, 'visibilitychange', () => {
     visibility.value = document.visibilityState
-  }, undefined, document)
+  }, undefined)
 
   return visibility
 }

--- a/packages/core/useEventListener/index.ts
+++ b/packages/core/useEventListener/index.ts
@@ -1,32 +1,42 @@
-import { isClient, tryOnUnmounted } from '@vueuse/shared'
+import { isClient, isString, tryOnUnmounted } from '@vueuse/shared'
 
-export interface EventTarget<Events> {
+interface InferEventTarget<Events> {
   addEventListener(event: Events, fn?: any, options?: any): any
-  removeEventListener(name: Events, fn?: any, options?: any): any
+  removeEventListener(event: Events, fn?: any, options?: any): any
 }
 
-// overload 1: window
-export function useEventListener<K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void
-// overload 2: document
-export function useEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions, target?: Document): void
-// overload 3: custom event targets
-export function useEventListener<Names extends string>(type: Names, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions, target?: EventTarget<Names>): void
-// overload 4: any event target you believe working
-export function useEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions, target?: any): void
+export type WindowEventName = keyof WindowEventMap
+export type DocumentEventName = keyof DocumentEventMap
+
+// overload 1: window (omitted)
+export function useEventListener<E extends keyof WindowEventMap>(event: E, listener: (this: Window, ev: WindowEventMap[E]) => any, options?: boolean | AddEventListenerOptions): void
+// overload 2: window
+export function useEventListener<E extends keyof WindowEventMap>(target: Window, event: E, listener: (this: Window, ev: WindowEventMap[E]) => any, options?: boolean | AddEventListenerOptions): void
+// overload 3: document
+export function useEventListener<E extends keyof DocumentEventMap>(target: Document, event: E, listener: (this: Document, ev: DocumentEventMap[E]) => any, options?: boolean | AddEventListenerOptions): void
+// overload 4: custom event targets
+export function useEventListener<Names extends string>(target: InferEventTarget<Names>, event: Names, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void
+// overload 5: any event target you believe working
+export function useEventListener(target: EventTarget, event: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void
 
 // implementation
-export function useEventListener(
-  type: string,
-  listener: EventListenerOrEventListenerObject,
-  options?: boolean | AddEventListenerOptions,
-  target: EventTarget<any> | undefined = isClient ? window : undefined,
-) {
+export function useEventListener(...args: any[]) {
+  let target: EventTarget | undefined, event: string, listener: any, options: any
+
+  if (isString(args[0])) {
+    [event, listener, options] = args
+    target = isClient ? window : undefined
+  }
+  else {
+    [target, event, listener, options] = args
+  }
+
   if (!target)
     return
 
-  target.addEventListener(type, listener, options)
+  target.addEventListener(event, listener, options)
 
   tryOnUnmounted(() => {
-    target.removeEventListener(type, listener, options)
+    target!.removeEventListener(event, listener, options)
   })
 }

--- a/packages/core/useEventSource/index.ts
+++ b/packages/core/useEventSource/index.ts
@@ -41,7 +41,7 @@ export function useEventSource(url: string, events: Array<string> = []) {
     }
 
     for (const event_name of events) {
-      useEventListener(event_name, (e: Event & { data?: string }) => {
+      useEventListener(es, event_name, (e: Event & { data?: string }) => {
         event.value = event_name
         data.value = e.data || null
       })

--- a/packages/core/useIdle/index.ts
+++ b/packages/core/useIdle/index.ts
@@ -1,12 +1,12 @@
 import { ref } from 'vue-demi'
-import { timestamp, tryOnMounted } from '@vueuse/shared'
-import { useEventListener } from '../useEventListener'
+import { timestamp } from '@vueuse/shared'
+import { useEventListener, WindowEventName } from '../useEventListener'
 import { useThrottleFn } from '../useThrottleFn'
 
-const defaultEvents = ['mousemove', 'mousedown', 'resize', 'keydown', 'touchstart', 'wheel']
+const defaultEvents: WindowEventName[] = ['mousemove', 'mousedown', 'resize', 'keydown', 'touchstart', 'wheel']
 const oneMinute = 60e3
 
-export function useIdle(ms: number = oneMinute, initialState = false, listeningEvents: string[] = defaultEvents, throttleDelay = 50) {
+export function useIdle(ms: number = oneMinute, initialState = false, listeningEvents: WindowEventName[] = defaultEvents, throttleDelay = 50) {
   const idle = ref(initialState)
   const lastActive = ref(timestamp())
 
@@ -26,14 +26,12 @@ export function useIdle(ms: number = oneMinute, initialState = false, listeningE
   for (const eventName of listeningEvents)
     useEventListener(eventName, onEvent)
 
-  useEventListener('visibilitychange', () => {
+  useEventListener(document, 'visibilitychange', () => {
     if (!document.hidden)
       onEvent()
-  }, undefined, document)
+  }, undefined)
 
-  tryOnMounted(() => {
-    timeout = setTimeout(() => set(true), ms)
-  })
+  timeout = setTimeout(() => set(true), ms)
 
   return { idle, lastActive }
 }

--- a/packages/core/useNetwork/index.ts
+++ b/packages/core/useNetwork/index.ts
@@ -2,7 +2,6 @@
 
 import { ref, Ref } from 'vue-demi'
 import { useEventListener } from '../useEventListener'
-import { tryOnMounted } from '@vueuse/shared'
 
 export type NetworkType = 'bluetooth' | 'cellular' | 'ethernet' | 'none' | 'wifi' | 'wimax' | 'other' | 'unknown'
 
@@ -54,9 +53,9 @@ export function useNetwork() {
   })
 
   if (connection)
-    useEventListener('change', updateNetworkInformation, false, connection)
+    useEventListener(connection, 'change', updateNetworkInformation, false)
 
-  tryOnMounted(updateNetworkInformation)
+  updateNetworkInformation()
 
   return {
     isOnline,

--- a/packages/core/usePermission/index.ts
+++ b/packages/core/usePermission/index.ts
@@ -32,7 +32,7 @@ export function usePermission(permissionDesc: GeneralPermissionDescriptor | Perm
       .then((status) => {
         permissionStatus = status
         onChange()
-        useEventListener('change', onChange, undefined, permissionStatus)
+        useEventListener(permissionStatus, 'change', onChange, undefined)
       })
       .catch(noop)
   }


### PR DESCRIPTION
should be more intuitive

from 
```ts
  useEventListener('visibilitychange', handler, undefined, document)
```

to

```ts
  useEventListener(document, 'visibilitychange', handler)
```