### PR TITLE
refactor!(useWebWorkerFn): export WebWorkerStatus as type instead of enum

### DIFF
--- a/packages/core/useWebWorkerFn/index.md
+++ b/packages/core/useWebWorkerFn/index.md
@@ -23,9 +23,9 @@ import { useWebWorkerFn } from '@vueuse/core'
 const fn = dates => dates.sort(dateFns.compareAsc)
 
 const { workerFn, workerStatus, workerTerminate } = useWebWorkerFn(fn, {
-  timeout: 50000, // 5 seconds
+  timeout: 5_000, // 5 seconds
   dependencies: [
-    "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js" // dateFns
+    'https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js' // dateFns
   ],
 })
 ```
@@ -56,8 +56,8 @@ Before you start using this function, we suggest you read the [Web Worker](https
 | Name            | Type             | Description                                                |
 | --------------- | ---------------- | ---------------------------------------------------------- |
 | workerFn        | Promise          | The `function` that allows you to run `fn` with web worker |
-| workerStatus    | `workerStatus`   | The status of `workerFn`                                   |
-| workerTerminate | Function         | The function that kill the worker                          |
+| workerStatus    | `WebWorkerStatus`   | The status of `workerFn`                                   |
+| workerTerminate | Function         | The function that kills the worker                          |
 
 ## Credit
 

--- a/packages/core/useWebWorkerFn/index.stories.tsx
+++ b/packages/core/useWebWorkerFn/index.stories.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import { storiesOf } from '@storybook/vue'
 import { defineComponent } from 'vue-demi'
 import { ShowDocs } from '../../_docs/showdocs'
-import { useWebWorkerFn, WorkerStatus } from './'
+import { useWebWorkerFn } from './'
 import { useNow } from '../useNow'
 
 type Inject = {
@@ -56,7 +56,7 @@ const Demo = defineComponent({
             Normal Sort
           </button>
           {
-            workerStatus !== WorkerStatus.Runing ? (
+            workerStatus !== 'RUNNING' ? (
               <button onClick={() => workerSort()}>
                 Worker Sort
               </button>

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -4,7 +4,7 @@ import { ref, Ref } from 'vue-demi'
 import createWorkerBlobUrl from './lib/createWorkerBlobUrl'
 import { tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
 
-export const enum WorkerStatus {
+export enum WorkerStatus {
   Pending = 'PENDING',
   Success = 'SUCCESS',
   Runing = 'RUNNING',

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -2,32 +2,29 @@
 
 import { ref, Ref } from 'vue-demi'
 import createWorkerBlobUrl from './lib/createWorkerBlobUrl'
-import { tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
+import { tryOnUnmounted } from '@vueuse/shared'
 
-export type WorkerStatus = 'PENDING' | 'SUCCESS' | 'RUNNING' | 'ERROR' | 'TIMEOUT_EXPIRED'
+export type WebWorkerStatus = 'PENDING' | 'SUCCESS' | 'RUNNING' | 'ERROR' | 'TIMEOUT_EXPIRED'
 
-type Options = {
+export type WebWorkerOptions = {
   timeout?: number
   dependencies?: string[]
 }
 
-const DEFAULT_OPTIONS: Options = {
-  timeout: undefined,
-  dependencies: [],
-}
-
-/* eslint-disable arrow-parens */
 export const useWebWorkerFn = <T extends (...fnArgs: any[]) => any>(
-  fn: T, options: Options = DEFAULT_OPTIONS,
+  fn: T,
+  {
+    dependencies = [],
+    timeout,
+  }: WebWorkerOptions = {},
 ) => {
-  /* eslint-enable arrow-parens */
   const worker: Ref<Worker & { _url?: string } | undefined> = ref(undefined)
 
-  const workerStatus: Ref<WorkerStatus> = ref(WorkerStatus.Pending)
+  const workerStatus = ref<WebWorkerStatus>('PENDING')
   const promise: Ref<{ reject?: (result: ReturnType<T> | ErrorEvent) => void;resolve?: (result: ReturnType<T>) => void }> = ref({})
   const timeoutId: Ref<number | undefined> = ref(undefined)
 
-  const workerTerminate = (status = WorkerStatus.Pending) => {
+  const workerTerminate = (status: WebWorkerStatus = 'PENDING') => {
     if (worker.value && worker.value._url) {
       worker.value.terminate()
       URL.revokeObjectURL(worker.value._url)
@@ -38,19 +35,13 @@ export const useWebWorkerFn = <T extends (...fnArgs: any[]) => any>(
     }
   }
 
-  tryOnMounted(() => {
-    workerTerminate()
-  })
+  workerTerminate()
 
   tryOnUnmounted(() => {
     workerTerminate()
   })
 
   const generateWorker = () => {
-    const {
-      dependencies = DEFAULT_OPTIONS.dependencies || [],
-      timeout = DEFAULT_OPTIONS.timeout,
-    } = options
     const blobUrl = createWorkerBlobUrl(fn, dependencies)
     const newWorker: Worker & { _url?: string } = new Worker(blobUrl)
     newWorker._url = blobUrl
@@ -60,16 +51,16 @@ export const useWebWorkerFn = <T extends (...fnArgs: any[]) => any>(
         resolve = () => {},
         reject = () => {},
       } = promise.value
-      const [status, result] = e.data as [WorkerStatus, ReturnType<T>]
+      const [status, result] = e.data as [WebWorkerStatus, ReturnType<T>]
 
       switch (status) {
-        case WorkerStatus.Success:
+        case 'SUCCESS':
           resolve(result)
           workerTerminate(status)
           break
         default:
           reject(result)
-          workerTerminate(WorkerStatus.Error)
+          workerTerminate('ERROR')
           break
       }
     }
@@ -80,12 +71,12 @@ export const useWebWorkerFn = <T extends (...fnArgs: any[]) => any>(
       } = promise.value
 
       reject(e)
-      workerTerminate(WorkerStatus.Error)
+      workerTerminate('ERROR')
     }
 
     if (timeout) {
       timeoutId.value = window.setTimeout(() => {
-        workerTerminate(WorkerStatus.TimeoutExpired)
+        workerTerminate('TIMEOUT_EXPIRED')
       }, timeout)
     }
     return newWorker
@@ -98,13 +89,13 @@ export const useWebWorkerFn = <T extends (...fnArgs: any[]) => any>(
     }
     worker.value && worker.value.postMessage([[...fnArgs]])
 
-    workerStatus.value = (WorkerStatus.Runing)
+    workerStatus.value = 'RUNNING'
   })
 
   const workerFn = (...fnArgs: Parameters<T>) => {
-    if (workerStatus.value === WorkerStatus.Runing) {
+    if (workerStatus.value === 'RUNNING') {
       /* eslint-disable-next-line no-console */
-      console.error('[useWebWorkerFn] You can only run one instance of the worker at a time, if you want to run more than one in parallel, create another instance with the hook useWorker(). Read more: https://github.com/alewin/useWorker')
+      console.error('[useWebWorkerFn] You can only run one instance of the worker at a time.')
       /* eslint-disable-next-line prefer-promise-reject-errors */
       return Promise.reject()
     }

--- a/packages/core/useWebWorkerFn/index.ts
+++ b/packages/core/useWebWorkerFn/index.ts
@@ -4,13 +4,7 @@ import { ref, Ref } from 'vue-demi'
 import createWorkerBlobUrl from './lib/createWorkerBlobUrl'
 import { tryOnMounted, tryOnUnmounted } from '@vueuse/shared'
 
-export enum WorkerStatus {
-  Pending = 'PENDING',
-  Success = 'SUCCESS',
-  Runing = 'RUNNING',
-  Error = 'ERROR',
-  TimeoutExpired = 'TIMEOUT_EXPIRED',
-}
+export type WorkerStatus = 'PENDING' | 'SUCCESS' | 'RUNNING' | 'ERROR' | 'TIMEOUT_EXPIRED'
 
 type Options = {
   timeout?: number


### PR DESCRIPTION
This is to allow use of the TypeScript compiler option --isolatedModules.

Fixes #172