### PR TITLE
BREAKING CHANGE: refactor!(useRefHistory): flush 'pre' as default for useRefHistory

### DIFF
--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -1,24 +1,36 @@
 # useRefHistory
 
-> Track the change history of a ref, also provide undo and redo functionality
+> Track the change history of a ref, also provides undo and redo functionality
 
 ## Usage
 
 ```ts
-import { ref } from 'vue' 
+import { ref } from 'vue'
 import { useRefHistory } from '@vueuse/core'
 
 const counter = ref(0)
 const { history, undo, redo } = useRefHistory(counter)
+```
 
+Internally, `watch` is used to trigger a history point when the ref value is modified. This means that history points are triggered asynchronously batching modifications in the same "tick".
+
+```ts
 counter.value += 1
-counter.value = 10
 
-console.log(history.value) // [{ value: 10, timestamp: 1601912898062 }, { value: 1, timestamp: 1601912898061 }]
+await nextTick()
+console.log(history.value)
+/* [
+  { value: 1, timestamp: 1601912898062 }, 
+  { value: 0, timestamp: 1601912898061 }
+] */
+```
 
-console.log(counter.value) // 10
+You can use `undo` to reset the ref value to the last history point.
+
+```ts
+console.log(counter.value) // 1
 undo()
-console.log(counter.value) // 1 
+console.log(counter.value) // 0
 ```
 
 ### Objects / arrays
@@ -28,7 +40,7 @@ When working with objects or arrays, since changing their attributes does not ch
 ```ts
 const state = ref({
   foo: 1,
-  bar: 'bar'
+  bar: "bar",
 })
 
 const { history, undo, redo } = useRefHistory(state, {
@@ -37,7 +49,8 @@ const { history, undo, redo } = useRefHistory(state, {
 
 state.value.foo = 2
 
-console.log(history.value) 
+await nextTick()
+console.log(history.value)
 /* [
   { value: { foo: 2, bar: 'bar' } },
   { value: { foo: 1, bar: 'bar' } }
@@ -66,15 +79,66 @@ import { useRefHistory } from '@vueuse/core'
 const refHistory = useRefHistory(target, { dump: klona })
 ```
 
-
 ### History Capacity
 
 We will keep all the history by default (unlimited) until you explicitly clean them up, you can set the maximal amount of history to be kept by `capacity` options.
 
 ```ts
 const refHistory = useRefHistory(target, {
-  capacity: 15 // limit to 15 history records
+  capacity: 15, // limit to 15 history records
 })
 
 refHistory.clean() // explicitly clean all the history
+```
+
+### History Flush Timing
+
+From [Vue's documentation](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing): Vue's reactivity system buffers invalidated effects and flushes them asynchronously to avoid unnecessary duplicate invocation when there are many state mutations happening in the same "tick".
+
+In the same way as `watch`, you can modify the flush timing using the `flush` option.
+
+```
+const refHistory = useRefHistory(target, {
+  flush: 'sync' // options 'pre' (default), 'post' and 'sync'
+})
+```
+
+The default is `'pre'`, to align this composable with the default for Vue's watchers. This also helps to avoid common issues, like several history points generated as part of a multi step update to a ref value that can break invariants of the app state. You can use `commit()` in case you need to create multiple history points in the same "tick"
+
+```ts
+const r = ref(0)
+const { history, commit } = useRefHistory(r)
+
+r.value = 1
+commit()
+
+r.value = 2
+commit()
+
+console.log(history.value)
+/* [
+  { value: 2 },
+  { value: 1 },
+  { value: 0 },
+] */
+```
+
+On the other hand, when using flush `'sync'`, you can use `batch(fn)` to generate a single history point for several sync operations
+
+```ts
+const r = ref({ names: [], version: 1 })
+const { history, batch } = useRefHistory(r, {
+  flush: "sync",
+})
+
+batch(() => {
+  r.names.push("Lena")
+  r.version++
+})
+
+console.log(history.value)
+/* [
+  { value: { names: [ 'Lena' ], version: 2 },
+  { value: { names: [], version: 1 },
+] */
 ```

--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -40,7 +40,7 @@ When working with objects or arrays, since changing their attributes does not ch
 ```ts
 const state = ref({
   foo: 1,
-  bar: "bar",
+  bar: 'bar',
 })
 
 const { history, undo, redo } = useRefHistory(state, {
@@ -93,17 +93,17 @@ refHistory.clean() // explicitly clean all the history
 
 ### History Flush Timing
 
-From [Vue's documentation](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing): Vue's reactivity system buffers invalidated effects and flushes them asynchronously to avoid unnecessary duplicate invocation when there are many state mutations happening in the same "tick".
+From [Vue's documentation](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing): Vue's reactivity system buffers invalidated effects and flush them asynchronously to avoid unnecessary duplicate invocation when there are many state mutations happening in the same "tick".
 
 In the same way as `watch`, you can modify the flush timing using the `flush` option.
 
-```
+```ts
 const refHistory = useRefHistory(target, {
   flush: 'sync' // options 'pre' (default), 'post' and 'sync'
 })
 ```
 
-The default is `'pre'`, to align this composable with the default for Vue's watchers. This also helps to avoid common issues, like several history points generated as part of a multi step update to a ref value that can break invariants of the app state. You can use `commit()` in case you need to create multiple history points in the same "tick"
+The default is `'pre'`, to align this composable with the default for Vue's watchers. This also helps to avoid common issues, like several history points generated as part of a multi-step update to a ref value that can break invariants of the app state. You can use `commit()` in case you need to create multiple history points in the same "tick"
 
 ```ts
 const r = ref(0)
@@ -127,12 +127,10 @@ On the other hand, when using flush `'sync'`, you can use `batch(fn)` to generat
 
 ```ts
 const r = ref({ names: [], version: 1 })
-const { history, batch } = useRefHistory(r, {
-  flush: "sync",
-})
+const { history, batch } = useRefHistory(r, { flush: 'sync' })
 
 batch(() => {
-  r.names.push("Lena")
+  r.names.push('Lena')
   r.version++
 })
 

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -1,3 +1,4 @@
+import { toUnicode } from 'punycode'
 import { ref } from 'vue-demi'
 import { useRefHistory } from '.'
 import { renderHook } from '../../_docs/tests'
@@ -256,11 +257,11 @@ describe('useRefHistory', () => {
   })
 
   test('pre: commit', async() => {
-    renderHook(() => {
-    })
+    const instance = renderHook(() => {
+    }).vm
 
     const v = ref(0)
-    const { commit, history } = useRefHistory(v)
+    const { commit, history, undo } = useRefHistory(v)
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toBe(0)
@@ -269,6 +270,15 @@ describe('useRefHistory', () => {
 
     expect(history.value.length).toBe(2)
     expect(history.value[0].value).toBe(0)
+    expect(history.value[1].value).toBe(0)
+
+    undo()
+    v.value = 2
+    commit()
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe(2)
     expect(history.value[1].value).toBe(0)
   })
 

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -1,4 +1,3 @@
-import { toUnicode } from 'punycode'
 import { ref } from 'vue-demi'
 import { useRefHistory } from '.'
 import { renderHook } from '../../_docs/tests'
@@ -282,7 +281,7 @@ describe('useRefHistory', () => {
     expect(history.value[1].value).toBe(0)
   })
 
-  test('pre: pause and resume', async () => {
+  test('pre: pause and resume', async() => {
     const instance = renderHook(() => {
     }).vm
 

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -3,10 +3,10 @@ import { useRefHistory } from '.'
 import { renderHook } from '../../_docs/tests'
 
 describe('useRefHistory', () => {
-  test('should record', () => {
+  test('sync: should record', () => {
     renderHook(() => {
       const v = ref(0)
-      const { history } = useRefHistory(v)
+      const { history } = useRefHistory(v, { flush: 'sync' })
 
       expect(history.value.length).toBe(1)
       expect(history.value[0].value).toBe(0)
@@ -19,10 +19,10 @@ describe('useRefHistory', () => {
     })
   })
 
-  test('should be able to undo and redo', () => {
+  test('sync: should be able to undo and redo', () => {
     renderHook(() => {
       const v = ref(0)
-      const { undo, redo, history } = useRefHistory(v)
+      const { undo, redo, history } = useRefHistory(v, { flush: 'sync' })
 
       v.value = 2
       v.value = 3
@@ -43,10 +43,10 @@ describe('useRefHistory', () => {
     })
   })
 
-  test('object with deep', () => {
+  test('sync: object with deep', () => {
     renderHook(() => {
       const v = ref({ foo: 'bar' })
-      const { history } = useRefHistory(v, { deep: true })
+      const { history } = useRefHistory(v, { flush: 'sync', deep: true })
 
       expect(history.value.length).toBe(1)
       expect(history.value[0].value.foo).toBe('bar')
@@ -62,10 +62,11 @@ describe('useRefHistory', () => {
     })
   })
 
-  test('dump + parse', () => {
+  test('sync: dump + parse', () => {
     renderHook(() => {
       const v = ref({ a: 'bar' })
       const { history, undo } = useRefHistory(v, {
+        flush: 'sync',
         deep: true,
         dump: v => JSON.stringify(v),
         parse: (v: string) => JSON.parse(v),
@@ -86,9 +87,9 @@ describe('useRefHistory', () => {
     })
   })
 
-  test('commit', () => {
+  test('sync: commit', () => {
     const v = ref(0)
-    const { commit, history } = useRefHistory(v)
+    const { commit, history } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toBe(0)
@@ -100,9 +101,9 @@ describe('useRefHistory', () => {
     expect(history.value[1].value).toBe(0)
   })
 
-  test('without batch', () => {
+  test('sync: without batch', () => {
     const v = ref({ foo: 1, bar: 'one' })
-    const { history } = useRefHistory(v, { deep: true })
+    const { history } = useRefHistory(v, { flush: 'sync', deep: true })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toEqual({ foo: 1, bar: 'one' })
@@ -116,9 +117,9 @@ describe('useRefHistory', () => {
     expect(history.value[2].value).toEqual({ foo: 1, bar: 'one' })
   })
 
-  test('with batch', () => {
+  test('sync: with batch', () => {
     const v = ref({ foo: 1, bar: 'one' })
-    const { history, batch } = useRefHistory(v, { deep: true })
+    const { history, batch } = useRefHistory(v, { flush: 'sync', deep: true })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toEqual({ foo: 1, bar: 'one' })
@@ -133,9 +134,9 @@ describe('useRefHistory', () => {
     expect(history.value[1].value).toEqual({ foo: 1, bar: 'one' })
   })
 
-  test('pause and resume', () => {
+  test('sync: pause and resume', () => {
     const v = ref(1)
-    const { history, pause, resume } = useRefHistory(v)
+    const { history, pause, resume } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toBe(1)
@@ -154,12 +155,156 @@ describe('useRefHistory', () => {
     expect(history.value.length).toBe(2)
     expect(history.value[0].value).toBe(3)
   })
+
+  test('pre: should record', async() => {
+    const instance = renderHook(() => {
+    }).vm
+
+    const v = ref(0)
+    const { history } = useRefHistory(v)
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toBe(0)
+
+    v.value = 2
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe(2)
+    expect(history.value[1].value).toBe(0)
+  })
+
+  test('pre: should be able to undo and redo', async() => {
+    const instance = renderHook(() => {
+    }).vm
+
+    const v = ref(0)
+    const { undo, redo, history } = useRefHistory(v)
+
+    v.value = 2
+    await instance.$nextTick()
+    v.value = 3
+    await instance.$nextTick()
+    v.value = 4
+    await instance.$nextTick()
+
+    expect(v.value).toBe(4)
+    expect(history.value.length).toBe(4)
+    undo()
+    await instance.$nextTick()
+    expect(v.value).toBe(3)
+    undo()
+    await instance.$nextTick()
+    expect(v.value).toBe(2)
+    redo()
+    await instance.$nextTick()
+    expect(v.value).toBe(3)
+    redo()
+    await instance.$nextTick()
+    expect(v.value).toBe(4)
+    redo()
+    await instance.$nextTick()
+    expect(v.value).toBe(4)
+  })
+
+  test('pre: object with deep', async() => {
+    const instance = renderHook(() => {
+    }).vm
+
+    const v = ref({ foo: 'bar' })
+    const { history } = useRefHistory(v, { deep: true })
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value.foo).toBe('bar')
+
+    v.value.foo = 'foo'
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value.foo).toBe('foo')
+
+    // different references
+    expect(history.value[1].value.foo).toBe('bar')
+    expect(history.value[0].value).not.toBe(history.value[1].value)
+  })
+
+  test('pre: dump + parse', async() => {
+    const instance = renderHook(() => {
+    }).vm
+
+    const v = ref({ a: 'bar' })
+    const { history, undo } = useRefHistory(v, {
+      deep: true,
+      dump: v => JSON.stringify(v),
+      parse: (v: string) => JSON.parse(v),
+    })
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toBe('{"a":"bar"}')
+
+    v.value.a = 'foo'
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe('{"a":"foo"}')
+    expect(history.value[1].value).toBe('{"a":"bar"}')
+
+    undo()
+    await instance.$nextTick()
+
+    expect(v.value.a).toBe('bar')
+  })
+
+  test('pre: commit', async() => {
+    renderHook(() => {
+    })
+
+    const v = ref(0)
+    const { commit, history } = useRefHistory(v)
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toBe(0)
+
+    commit()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe(0)
+    expect(history.value[1].value).toBe(0)
+  })
+
+  test('pre: pause and resume', async () => {
+    const instance = renderHook(() => {
+    }).vm
+
+    const v = ref(1)
+    const { history, pause, resume } = useRefHistory(v)
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].value).toBe(1)
+
+    pause()
+    v.value = 2
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(1)
+
+    resume()
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(1)
+
+    v.value = 3
+    await instance.$nextTick()
+
+    expect(history.value.length).toBe(2)
+    expect(history.value[0].value).toBe(3)
+  })
 })
 
-test('reset', () => {
+test('sync: reset', () => {
   renderHook(() => {
     const v = ref(0)
-    const { history, undoStack, redoStack, pause, reset, undo } = useRefHistory(v)
+    const { history, undoStack, redoStack, pause, reset, undo } = useRefHistory(v, { flush: 'sync' })
 
     expect(history.value.length).toBe(1)
     expect(history.value[0].value).toBe(0)
@@ -208,4 +353,64 @@ test('reset', () => {
     expect(redoStack.value.length).toBe(1)
     expect(redoStack.value[0].value).toBe(1)
   })
+})
+
+test('pre: reset', async() => {
+  const instance = renderHook(() => {
+  }).vm
+
+  const v = ref(0)
+  const { history, undoStack, redoStack, pause, reset, undo } = useRefHistory(v)
+
+  expect(history.value.length).toBe(1)
+  expect(history.value[0].value).toBe(0)
+
+  v.value = 1
+  await instance.$nextTick()
+
+  pause()
+
+  v.value = 2
+  await instance.$nextTick()
+
+  expect(history.value.length).toBe(2)
+  expect(history.value[0].value).toBe(1)
+  expect(history.value[1].value).toBe(0)
+
+  reset()
+
+  // v value needs to be the last history point, but history is unchanged
+  expect(v.value).toBe(1)
+
+  expect(history.value.length).toBe(2)
+  expect(history.value[0].value).toBe(1)
+  expect(history.value[1].value).toBe(0)
+
+  reset()
+
+  // Calling reset twice is a no-op
+  expect(v.value).toBe(1)
+
+  expect(history.value.length).toBe(2)
+  expect(history.value[1].value).toBe(0)
+  expect(history.value[0].value).toBe(1)
+
+  // Same test, but with a non empty redoStack
+
+  undo()
+  await instance.$nextTick()
+
+  v.value = 2
+  await instance.$nextTick()
+
+  reset()
+  await instance.$nextTick()
+
+  expect(v.value).toBe(0)
+
+  expect(undoStack.value.length).toBe(1)
+  expect(undoStack.value[0].value).toBe(0)
+
+  expect(redoStack.value.length).toBe(1)
+  expect(redoStack.value[0].value).toBe(1)
 })

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue-demi'
+import { ref, nextTick } from 'vue-demi'
 import { useRefHistory } from '.'
 import { renderHook } from '../../_docs/tests'
 
@@ -157,9 +157,6 @@ describe('useRefHistory', () => {
   })
 
   test('pre: should record', async() => {
-    const instance = renderHook(() => {
-    }).vm
-
     const v = ref(0)
     const { history } = useRefHistory(v)
 
@@ -167,7 +164,7 @@ describe('useRefHistory', () => {
     expect(history.value[0].value).toBe(0)
 
     v.value = 2
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(2)
     expect(history.value[0].value).toBe(2)
@@ -175,42 +172,36 @@ describe('useRefHistory', () => {
   })
 
   test('pre: should be able to undo and redo', async() => {
-    const instance = renderHook(() => {
-    }).vm
-
     const v = ref(0)
     const { undo, redo, history } = useRefHistory(v)
 
     v.value = 2
-    await instance.$nextTick()
+    await nextTick()
     v.value = 3
-    await instance.$nextTick()
+    await nextTick()
     v.value = 4
-    await instance.$nextTick()
+    await nextTick()
 
     expect(v.value).toBe(4)
     expect(history.value.length).toBe(4)
     undo()
-    await instance.$nextTick()
+    await nextTick()
     expect(v.value).toBe(3)
     undo()
-    await instance.$nextTick()
+    await nextTick()
     expect(v.value).toBe(2)
     redo()
-    await instance.$nextTick()
+    await nextTick()
     expect(v.value).toBe(3)
     redo()
-    await instance.$nextTick()
+    await nextTick()
     expect(v.value).toBe(4)
     redo()
-    await instance.$nextTick()
+    await nextTick()
     expect(v.value).toBe(4)
   })
 
   test('pre: object with deep', async() => {
-    const instance = renderHook(() => {
-    }).vm
-
     const v = ref({ foo: 'bar' })
     const { history } = useRefHistory(v, { deep: true })
 
@@ -218,7 +209,7 @@ describe('useRefHistory', () => {
     expect(history.value[0].value.foo).toBe('bar')
 
     v.value.foo = 'foo'
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(2)
     expect(history.value[0].value.foo).toBe('foo')
@@ -229,9 +220,6 @@ describe('useRefHistory', () => {
   })
 
   test('pre: dump + parse', async() => {
-    const instance = renderHook(() => {
-    }).vm
-
     const v = ref({ a: 'bar' })
     const { history, undo } = useRefHistory(v, {
       deep: true,
@@ -243,22 +231,19 @@ describe('useRefHistory', () => {
     expect(history.value[0].value).toBe('{"a":"bar"}')
 
     v.value.a = 'foo'
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(2)
     expect(history.value[0].value).toBe('{"a":"foo"}')
     expect(history.value[1].value).toBe('{"a":"bar"}')
 
     undo()
-    await instance.$nextTick()
+    await nextTick()
 
     expect(v.value.a).toBe('bar')
   })
 
   test('pre: commit', async() => {
-    const instance = renderHook(() => {
-    }).vm
-
     const v = ref(0)
     const { commit, history, undo } = useRefHistory(v)
 
@@ -274,7 +259,7 @@ describe('useRefHistory', () => {
     undo()
     v.value = 2
     commit()
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(2)
     expect(history.value[0].value).toBe(2)
@@ -282,9 +267,6 @@ describe('useRefHistory', () => {
   })
 
   test('pre: pause and resume', async() => {
-    const instance = renderHook(() => {
-    }).vm
-
     const v = ref(1)
     const { history, pause, resume } = useRefHistory(v)
 
@@ -293,17 +275,17 @@ describe('useRefHistory', () => {
 
     pause()
     v.value = 2
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(1)
 
     resume()
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(1)
 
     v.value = 3
-    await instance.$nextTick()
+    await nextTick()
 
     expect(history.value.length).toBe(2)
     expect(history.value[0].value).toBe(3)
@@ -365,9 +347,6 @@ test('sync: reset', () => {
 })
 
 test('pre: reset', async() => {
-  const instance = renderHook(() => {
-  }).vm
-
   const v = ref(0)
   const { history, undoStack, redoStack, pause, reset, undo } = useRefHistory(v)
 
@@ -375,12 +354,12 @@ test('pre: reset', async() => {
   expect(history.value[0].value).toBe(0)
 
   v.value = 1
-  await instance.$nextTick()
+  await nextTick()
 
   pause()
 
   v.value = 2
-  await instance.$nextTick()
+  await nextTick()
 
   expect(history.value.length).toBe(2)
   expect(history.value[0].value).toBe(1)
@@ -407,13 +386,13 @@ test('pre: reset', async() => {
   // Same test, but with a non empty redoStack
 
   undo()
-  await instance.$nextTick()
+  await nextTick()
 
   v.value = 2
-  await instance.$nextTick()
+  await nextTick()
 
   reset()
-  await instance.$nextTick()
+  await nextTick()
 
   expect(v.value).toBe(0)
 

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -147,6 +147,8 @@ export function useRefHistory<Raw, Serialized = Raw>(
   }
 
   const commit = () => {
+    syncCounter.value = ignoreCounter.value
+
     undoStack.value.unshift({
       value: _dump(current.value),
       timestamp: timestamp(),
@@ -179,12 +181,10 @@ export function useRefHistory<Raw, Serialized = Raw>(
     )
   }
   else {
-    commit()
-
     const _asyncStop = watch(
       current,
       () => {
-        const ignore = ignoreCounter.value === syncCounter.value
+        const ignore = ignoreCounter.value > 0 && ignoreCounter.value === syncCounter.value
         ignoreCounter.value = 0
         syncCounter.value = 0
         if (ignore)
@@ -195,6 +195,7 @@ export function useRefHistory<Raw, Serialized = Raw>(
       },
       {
         deep: options.deep,
+        immediate: true,
         flush: _flush,
       },
     )


### PR DESCRIPTION
As discussed in https://github.com/antfu/vueuse/issues/181, this PR aligns useRefHistory with watch/watchEffect using flush: 'pre' as the default. As stated in the Vue docs, flush: 'sync' should only be used in rare cases. After our experience working with this composable, I think it is worth the effort to try to find a way to use 'pre'

In the current PR, there are new tests for the new default case, and the old tests are also working when using flush: 'sync'. I tried to follow the async pattern in other composable.

batch only makes sense when using 'sync'

Supported operations in sync when using 'pre'
  undo, undo
  undo, modify
  modify, undo (but the modification is lost)
  modify, commit, modify, commit, undo
  undo, modify, commit

We could also directly define that undo/redo and other history operations can not be chained with other sync modifications. But I tried to support them here.
