### PR TITLE
fix(useRafFn): incorrect lifecycle hook

### DIFF
--- a/packages/core/useRafFn/index.ts
+++ b/packages/core/useRafFn/index.ts
@@ -1,4 +1,4 @@
-import { tryOnMounted } from '@vueuse/shared'
+import { tryOnUnmounted } from '@vueuse/shared'
 
 export function useRafFn(fn: () => any, options: {startNow?: boolean} = {}) {
   const { startNow = true } = options
@@ -25,7 +25,7 @@ export function useRafFn(fn: () => any, options: {startNow?: boolean} = {}) {
   if (startNow)
     start()
 
-  tryOnMounted(() => stop())
+  tryOnUnmounted(() => stop())
 
   return { stop, start }
 }

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -1,0 +1,42 @@
+import { ref } from 'vue-demi'
+import { renderHook } from '../../_docs/tests'
+import { useTransition } from '.'
+
+describe('useTransition', () => {
+  it('transitions between values', (done) => {
+    const { vm } = renderHook(() => {
+      const baseValue = ref(0);
+
+      const transitionedValue = useTransition(baseValue, {
+        duration: 100,
+        transition: n => n, // a simple linear transition
+      })
+
+      return {
+        baseValue,
+        transitionedValue
+      }
+    })
+
+    // both values should start at zero
+    expect(vm.baseValue).toBe(0)
+    expect(vm.transitionedValue).toBe(0)
+
+    // changing the base value should start the transition
+    vm.baseValue = 1
+
+    setTimeout(() => {
+      // half way through the transition the base value should be 1,
+      // and the transitioned value should be approximately 0.5
+      expect(vm.baseValue).toBe(1)
+      expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)
+      
+      setTimeout(() => {
+        // once the transition is complete, both values should be 1
+        expect(vm.baseValue).toBe(1)
+        expect(vm.transitionedValue).toBe(1)
+        done()
+      }, 100)
+    }, 50)
+  })
+})

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -9,7 +9,7 @@ describe('useTransition', () => {
 
       const transitionedValue = useTransition(baseValue, {
         duration: 100,
-        transition: n => n, // a simple linear transition
+        transition: [0, 0, 1, 1], // a simple linear transition
       })
 
       return {

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -5,7 +5,7 @@ import { useTransition } from '.'
 describe('useTransition', () => {
   it('transitions between values', (done) => {
     const { vm } = renderHook(() => {
-      const baseValue = ref(0);
+      const baseValue = ref(0)
 
       const transitionedValue = useTransition(baseValue, {
         duration: 100,
@@ -14,7 +14,7 @@ describe('useTransition', () => {
 
       return {
         baseValue,
-        transitionedValue
+        transitionedValue,
       }
     })
 
@@ -30,7 +30,7 @@ describe('useTransition', () => {
       // and the transitioned value should be approximately 0.5
       expect(vm.baseValue).toBe(1)
       expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)
-      
+
       setTimeout(() => {
         // once the transition is complete, both values should be 1
         expect(vm.baseValue).toBe(1)


### PR DESCRIPTION
It looks like [in this commit](https://github.com/antfu/vueuse/commit/eda2fd4b7fb7072fd7bb56fbbe886114fec661fa#diff-80fba29722597fce2f73a9b693b85a627c4c4192a581f0af7cd3f3ce0e68ebdeL28-R28) the lifecycle binding was accidentally changed from `onUnmounted` to `onMounted`.

This caused [`useRafFn`](https://vueuse.js.org/?path=/story/animation--useraffn) to immediately stop it's animation loop, and had the cascading effect of breaking [`useTransition`](https://vueuse.js.org/?path=/story/animation--usetransition) which relies on that loop.