### PR TITLE
Clean up useTransition function

### DIFF
--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -9,7 +9,7 @@ import { useTransition } from '@vueuse/core'
 
 useTransition(baseNumber, {
   duration: 1000,
-  transition: 'easeInOutCubic',
+  transition: [0.75, 0, 0.25, 1],
 })
 ```
 

--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -51,7 +51,7 @@ useTransition(baseNumber, {
 For more complex transitions, a custom function can be provided.
 
 ```js
-const easeOutElastic = n => {
+const easeOutElastic = (n) => {
   return n === 0
     ? 0
     : n === 1

--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -13,33 +13,33 @@ useTransition(baseNumber, {
 })
 ```
 
-The following transitions are included as part of the `TransitionPresets` constant. See [easings.net](https://easings.net/en) for an example of each of these.
+The following transitions are available via the `TransitionPresets` constant.
 
-- `linear`
-- `easeInSine`
-- `easeOutSine`
-- `easeInQuad`
-- `easeOutQuad`
-- `easeInCubic`
-- `easeOutCubic`
-- `easeInOutCubic`
-- `easeInQuart`
-- `easeOutQuart`
-- `easeInOutQuart`
-- `easeInQuint`
-- `easeOutQuint`
-- `easeInOutQuint`
-- `easeInExpo`
-- `easeOutExpo`
-- `easeInOutExpo`
-- `easeInCirc`
-- `easeOutCirc`
-- `easeInOutCirc`
-- `easeInBack`
-- `easeOutBack`
-- `easeInOutBack`
+- [`linear`](https://cubic-bezier.com/#0,0,1,1)
+- [`easeInSine`](https://cubic-bezier.com/#.12,0,.39,0)
+- [`easeOutSine`](https://cubic-bezier.com/#.61,1,.88,1)
+- [`easeInQuad`](https://cubic-bezier.com/#.11,0,.5,0)
+- [`easeOutQuad`](https://cubic-bezier.com/#.5,1,.89,1)
+- [`easeInCubic`](https://cubic-bezier.com/#.32,0,.67,0)
+- [`easeOutCubic`](https://cubic-bezier.com/#.33,1,.68,1)
+- [`easeInOutCubic`](https://cubic-bezier.com/#.65,0,.35,1)
+- [`easeInQuart`](https://cubic-bezier.com/#.5,0,.75,0)
+- [`easeOutQuart`](https://cubic-bezier.com/#.25,1,.5,1)
+- [`easeInOutQuart`](https://cubic-bezier.com/#.76,0,.24,1)
+- [`easeInQuint`](https://cubic-bezier.com/#.64,0,.78,0)
+- [`easeOutQuint`](https://cubic-bezier.com/#.22,1,.36,1)
+- [`easeInOutQuint`](https://cubic-bezier.com/#.83,0,.17,1)
+- [`easeInExpo`](https://cubic-bezier.com/#.7,0,.84,0)
+- [`easeOutExpo`](https://cubic-bezier.com/#.16,1,.3,1)
+- [`easeInOutExpo`](https://cubic-bezier.com/#.87,0,.13,1)
+- [`easeInCirc`](https://cubic-bezier.com/#.55,0,1,.45)
+- [`easeOutCirc`](https://cubic-bezier.com/#0,.55,.45,1)
+- [`easeInOutCirc`](https://cubic-bezier.com/#.85,0,.15,1)
+- [`easeInBack`](https://cubic-bezier.com/#0.12,0,0.39,0)
+- [`easeOutBack`](https://cubic-bezier.com/#.34,1.56,.64,1)
+- [`easeInOutBack`](https://cubic-bezier.com/#.68,-.6,.32,1.6)
 
-Custom transitions can be defined using [cubic bezier curves](https://cubic-bezier.com/#.75,0,.25,1).
+Custom transitions can be defined using cubic bezier curves. Transitions defined this way work the same as [CSS easing functions](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function).
 
 ```js
 useTransition(baseNumber, {
@@ -51,7 +51,7 @@ useTransition(baseNumber, {
 For more complex transitions, a custom function can be provided.
 
 ```js
-const easeOutElastic = (n) => {
+const easeOutElastic = n => {
   return n === 0
     ? 0
     : n === 1

--- a/packages/core/useTransition/index.md
+++ b/packages/core/useTransition/index.md
@@ -5,15 +5,15 @@
 ## Usage
 
 ```js
-import { useTransition } from '@vueuse/core'
+import { useTransition, TransitionPresets } from '@vueuse/core'
 
 useTransition(baseNumber, {
   duration: 1000,
-  transition: [0.75, 0, 0.25, 1],
+  transition: TransitionPresets.easeInOutCubic,
 })
 ```
 
-The following transitions are available out of the box. Check out [easings.net](https://easings.net/en) for an example of each of these.
+The following transitions are included as part of the `TransitionPresets` constant. See [easings.net](https://easings.net/en) for an example of each of these.
 
 - `linear`
 - `easeInSine`
@@ -39,4 +39,28 @@ The following transitions are available out of the box. Check out [easings.net](
 - `easeOutBack`
 - `easeInOutBack`
 
-Custom transitions can be provided as an array of numbers, or a custom function. For example, [`[0.75, 0, 0.25, 1]`](https://cubic-bezier.com/#.75,0,.25,1) would be an ease-in-out transition.
+Custom transitions can be defined using [cubic bezier curves](https://cubic-bezier.com/#.75,0,.25,1).
+
+```js
+useTransition(baseNumber, {
+  duration: 1000,
+  transition: [0.75, 0, 0.25, 1],
+})
+```
+
+For more complex transitions, a custom function can be provided.
+
+```js
+const easeOutElastic = (n) => {
+  return n === 0
+    ? 0
+    : n === 1
+      ? 1
+      : (2 ** (-10 * n)) * Math.sin((n * 10 - 0.75) * ((2 * Math.PI) / 3)) + 1
+}
+
+useTransition(baseNumber, {
+  duration: 1000,
+  transition: easeInOutElastic,
+})
+```

--- a/packages/core/useTransition/index.stories.tsx
+++ b/packages/core/useTransition/index.stories.tsx
@@ -32,12 +32,12 @@ defineDemo(
     setup() {
       const baseNumber = ref(0)
 
-      const easeInOutElastic = (x: number) => {
-        const c5 = (2 * Math.PI) / 4.5
-        return x === 0
-          ? 0 : x === 1
-            ? 1 : x < 0.5
-              ? -(2 ** (20 * x - 10) * Math.sin((20 * x - 11.125) * c5)) / 2 : (2 ** (-20 * x + 10) * Math.sin((20 * x - 11.125) * c5)) / 2 + 1
+      const easeOutElastic = (n: number) => {
+        return n === 0
+          ? 0
+          : n === 1
+            ? 1
+            : (2 ** (-10 * n)) * Math.sin((n * 10 - 0.75) * ((2 * Math.PI) / 3)) + 1
       }
 
       const cubicBezierNumber = useTransition(baseNumber, {
@@ -47,7 +47,7 @@ defineDemo(
 
       const customFnNumber = useTransition(baseNumber, {
         duration: 1500,
-        transition: easeInOutElastic,
+        transition: easeOutElastic,
       })
 
       return {

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -59,7 +59,34 @@ describe('useTransition', () => {
 
     setTimeout(() => {
       expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)
-      
+
+      setTimeout(() => {
+        expect(vm.transitionedValue).toBe(1)
+        done()
+      }, 100)
+    }, 50)
+  })
+
+  it('supports custom function transitions', (done) => {
+    const { vm } = renderHook(() => {
+      const baseValue = ref(0)
+
+      const transitionedValue = useTransition(baseValue, {
+        duration: 100,
+        transition: n => n,
+      })
+
+      return {
+        baseValue,
+        transitionedValue,
+      }
+    })
+
+    vm.baseValue = 1;
+
+    setTimeout(() => {
+      expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)
+
       setTimeout(() => {
         expect(vm.transitionedValue).toBe(1)
         done()

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue-demi'
 import { renderHook } from '../../_docs/tests'
-import { useTransition } from '.'
+import { useTransition, TransitionPresets } from '.'
 
 describe('useTransition', () => {
   it('transitions between values', (done) => {
@@ -34,6 +34,33 @@ describe('useTransition', () => {
       setTimeout(() => {
         // once the transition is complete, both values should be 1
         expect(vm.baseValue).toBe(1)
+        expect(vm.transitionedValue).toBe(1)
+        done()
+      }, 100)
+    }, 50)
+  })
+
+  it('exposes named presets', (done) => {
+    const { vm } = renderHook(() => {
+      const baseValue = ref(0)
+
+      const transitionedValue = useTransition(baseValue, {
+        duration: 100,
+        transition: TransitionPresets.linear
+      })
+
+      return {
+        baseValue,
+        transitionedValue,
+      }
+    })
+
+    vm.baseValue = 1;
+
+    setTimeout(() => {
+      expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)
+      
+      setTimeout(() => {
         expect(vm.transitionedValue).toBe(1)
         done()
       }, 100)

--- a/packages/core/useTransition/index.test.ts
+++ b/packages/core/useTransition/index.test.ts
@@ -46,7 +46,7 @@ describe('useTransition', () => {
 
       const transitionedValue = useTransition(baseValue, {
         duration: 100,
-        transition: TransitionPresets.linear
+        transition: TransitionPresets.linear,
       })
 
       return {
@@ -55,7 +55,7 @@ describe('useTransition', () => {
       }
     })
 
-    vm.baseValue = 1;
+    vm.baseValue = 1
 
     setTimeout(() => {
       expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)
@@ -82,7 +82,7 @@ describe('useTransition', () => {
       }
     })
 
-    vm.baseValue = 1;
+    vm.baseValue = 1
 
     setTimeout(() => {
       expect(vm.transitionedValue > 0 && vm.transitionedValue < 1).toBe(true)

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,6 +1,6 @@
 import { useRafFn } from '../useRafFn'
 import { Ref, ref, watch } from 'vue-demi'
-import { clamp, isFunction, noop } from '@vueuse/shared'
+import { clamp, isFunction } from '@vueuse/shared'
 
 type CubicBezier = [number, number, number, number]
 
@@ -76,26 +76,31 @@ export function useTransition(baseNumber: Ref<number>, options: StateEasingOptio
     ? normalizedOptions.transition
     : cubicBezier(normalizedOptions.transition)
 
-  let stop = noop
+  let diff = 0
+  let endAt = 0
+  let startAt = 0
+  let startValue = 0
+
+  const { start, stop } = useRafFn(() => {
+    const now = Date.now()
+    const progress = clamp(1 - ((endAt - now) / normalizedOptions.duration), 0, 1)
+
+    number.value = startValue + (diff * getValue(progress))
+
+    if (progress >= 1)
+      stop()
+  }, { startNow: false })
 
   watch(baseNumber, () => {
     stop()
 
-    const diff = baseNumber.value - number.value
-    const startValue = number.value
-    const startAt = Date.now()
-    const endAt = startAt + normalizedOptions.duration
+    diff = baseNumber.value - number.value
+    startValue = number.value
+    startAt = Date.now()
+    endAt = startAt + normalizedOptions.duration
 
-    stop = useRafFn(() => {
-      const now = Date.now()
-      const progress = clamp(1 - ((endAt - now) / normalizedOptions.duration), 0, 1)
-
-      number.value = startValue + (diff * getValue(progress))
-
-      if (progress >= 1)
-        stop()
-    }).stop
-  }, { immediate: true })
+    start()
+  })
 
   return number
 }

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -1,16 +1,14 @@
 import { useRafFn } from '../useRafFn'
 import { Ref, ref, watch } from 'vue-demi'
-import { clamp, isFunction, isString, noop } from '@vueuse/shared'
+import { clamp, isFunction, noop } from '@vueuse/shared'
 
 type CubicBezier = [number, number, number, number]
 
 type EasingFunction = (x: number) => number
 
-type NamedPreset = 'linear' | 'easeInSine' | 'easeOutSine' | 'easeInQuad' | 'easeOutQuad' | 'easeInCubic' | 'easeOutCubic' | 'easeInOutCubic' | 'easeInQuart' | 'easeOutQuart' | 'easeInOutQuart' | 'easeInQuint' | 'easeOutQuint' | 'easeInOutQuint' | 'easeInExpo' | 'easeOutExpo' | 'easeInOutExpo' | 'easeInCirc' | 'easeOutCirc' | 'easeInOutCirc' | 'easeInBack' | 'easeOutBack' | 'easeInOutBack'
-
 type StateEasingOptions = {
   duration?: number
-  transition?: EasingFunction | NamedPreset | CubicBezier
+  transition?: EasingFunction | CubicBezier
 }
 
 function cubicBezier([p0, p1, p2, p3]: CubicBezier): EasingFunction {
@@ -39,7 +37,7 @@ function cubicBezier([p0, p1, p2, p3]: CubicBezier): EasingFunction {
   return (x: number) => p0 === p1 && p2 === p3 ? x : calcBezier(getTforX(x), p1, p3)
 }
 
-const presets: { [key in NamedPreset]: CubicBezier } = {
+export const TransitionPresets: Record<string, CubicBezier> = {
   linear: [0, 0, 1, 1],
   easeInSine: [0.12, 0, 0.39, 0],
   easeOutSine: [0.61, 1, 0.88, 1],
@@ -70,17 +68,13 @@ export function useTransition(baseNumber: Ref<number>, options: StateEasingOptio
 
   const normalizedOptions = {
     duration: 500,
-    transition: 'linear',
+    transition: (n: number) => n,
     ...options,
   }
 
   const getValue = isFunction<EasingFunction>(normalizedOptions.transition)
     ? normalizedOptions.transition
-    : cubicBezier(
-      isString(normalizedOptions.transition)
-        ? presets[normalizedOptions.transition as NamedPreset]
-        : normalizedOptions.transition,
-    )
+    : cubicBezier(normalizedOptions.transition)
 
   let stop = noop
 


### PR DESCRIPTION
Closes https://github.com/antfu/vueuse/issues/187

@antfu The only significant change here was https://github.com/antfu/vueuse/pull/188/commits/68c82eb986ea7cc587b5c3bf6b018ce960a7dd31

Previously, `useRafFn` was being called every time the base number changed. This caused a new raf loop to be created every time, and bound a lifecycle event on `onUnmounted` to kill the loop when the component is destroyed. This might have actually been a bug though, because I believe calling `onUnmounted` outside the context of `setup` has no effect. Regardless though, now `useRafFn` will be called only once, and there are no behavior changes.