### PR TITLE
chore: add 'position: relative;' for markdown-body

### DIFF
--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -78,6 +78,7 @@
 
 html, body, div, .markdown-body {
   font-family: 'Roboto Slab', Arial, Helvetica, sans-serif;
+  position: relative;
 }
 
 .markdown-body,


### PR DESCRIPTION
Links and headings and not clickable/selectable on https://vueuse.js.org/?path=/story/sensors--usewindowscroll due to absolute div. I believe this change doesn't have any side effect on other docs.