### PR TITLE
docs(usePermission): remove undefined variable

### DIFF
--- a/packages/core/usePermission/index.stories.tsx
+++ b/packages/core/usePermission/index.stories.tsx
@@ -28,7 +28,6 @@ defineDemo(
             microphone,
             notifications,
             camera,
-            speaker,
             midi,
           }, null, 2)
         }}</pre>


### PR DESCRIPTION
[usePermission](https://vueuse.js.org/?path=/story/browser--usepermission) document is broken due to this undefined variable.

First I was trying to implement that permission. Looks like it is renamed to 'speaker-selection' from 'speaker' on latest draft. That require me to polyfill types like how you did for clipboard permission. Then I realized no one of existing browsers support that permission. And probably that's why this variable was removed.