### PR TITLE
chore: useTransition / useElementVisibility cleanup and jsdoc

### DIFF
--- a/packages/core/useElementVisibility/index.ts
+++ b/packages/core/useElementVisibility/index.ts
@@ -3,6 +3,13 @@ import { ref, Ref, watch } from 'vue-demi'
 import { useWindowScroll } from '../useWindowScroll'
 import { ConfigurableWindow, defaultWindow } from '../_configurable'
 
+/**
+ * Tracks the visibility of an element within the viewport.
+ *
+ * @see   {@link https://vueuse.js.org/useElementVisibility}
+ * @param element
+ * @param options
+ */
 export function useElementVisibility(
   element: Ref<Element|null|undefined>,
   { window = defaultWindow }: ConfigurableWindow = {},

--- a/packages/core/useTransition/index.ts
+++ b/packages/core/useTransition/index.ts
@@ -82,7 +82,7 @@ export function useTransition(source: Ref<number>, options: TransitionOptions = 
   const {
     duration = 500,
     transition = (n: number) => n,
-  } = options;
+  } = options
 
   const output = ref(source.value)
 


### PR DESCRIPTION
Just a couple tweaks to help get my functions ready for the stable release.

- `useRafFn` has `start`/`stop` marked as deprecated, renamed functions to `resume`/`pause`
- adds jsdoc to `useTransition`
- adds jsdoc to `useElementVisibility`
- minor cleanups to `useTransition` to improve readability