### PR TITLE
chore: remove relative

### DIFF
--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -78,7 +78,6 @@
 
 html, body, div, .markdown-body {
   font-family: 'Roboto Slab', Arial, Helvetica, sans-serif;
-  position: relative;
 }
 
 .markdown-body,

--- a/.storybook/style.css
+++ b/.storybook/style.css
@@ -104,10 +104,6 @@ html, body, div, .markdown-body {
   border-bottom-color: rgba(255, 255, 255, 0.1);
 }
 
-.markdown-body pre {
-  position: relative;
-}
-
 .sb-show-main a,
 .markdown-body a {
   color: #42b883;

--- a/packages/core/useWindowScroll/index.stories.tsx
+++ b/packages/core/useWindowScroll/index.stories.tsx
@@ -17,8 +17,11 @@ defineDemo(
     template: html`
       <div>
         <note>See scroll values in the lower right corner of the screen.</note>
+        <div style="position: absolute; width: 10000px; height: 10000px;"></div>
         <div id="demo" style="
           position: fixed;
+          top: 100%;
+          left: 100%;
           bottom: 0;
           right: 0;
           padding: 1em 5em 1em 1.5em;
@@ -27,7 +30,6 @@ defineDemo(
           <p>x: {{x}}</p>
           <p>y: {{y}}</p>
         </div>
-        <div style="position: absolute; width: 10000px; height: 10000px;"></div>
       </div>
     `,
   }),


### PR DESCRIPTION
I had issues with that when I was working on a modal demo for an utility function I'm currently working on.

I fixed select/click problem by pushing absolute div to outside of view. Also moved it up to make the texts selectable on fixed div.