### PR TITLE
docs(useRefHistory): add warning about splice in flush sync

### DIFF
--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -140,3 +140,16 @@ console.log(history.value)
   { snapshot: { names: [], version: 1 },
 ] */
 ```
+
+If `{ flush: 'sync', deep: true }` is used, `batch` is also useful when doing a mutable `splice` in an array. `splice` can generate up to three atomic operations that will be pushed to the ref history.
+
+```ts
+const arr = ref([1,2,3])
+const { history, batch } = useRefHistory(r, { deep: true, flush: 'sync' })
+
+batch(() => {
+  arr.value.splice(1,1) // batch ensures only one history point is generated
+})
+```
+
+Another option is to avoid mutating the original ref value using `arr.value = [...arr.value].splice(1,1)`.


### PR DESCRIPTION
I [asked today in VueLand](https://discord.com/channels/325477692906536972/713147202188607558/778634528172015636) and at least there, they think that splice generating three flushes for a single operation is not a bug in Vue3 reactivity. For the moment, this PR adds a small note about this for useRefHistory