### PR TITLE
fix(useClipboard): set clipboard text only if successful

### DIFF
--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -30,9 +30,8 @@ export function useClipboard({ navigator = defaultNavigator }: ConfigurableNavig
   async function copy(txt: string) {
     if (isSupported) {
       // @ts-expect-error untyped API
-      await navigator.clipboard.writeText(txt).then(() => {
-        text.value = txt
-      })
+      await navigator.clipboard.writeText(txt)
+      text.value = txt
     }
   }
 

--- a/packages/core/useClipboard/index.ts
+++ b/packages/core/useClipboard/index.ts
@@ -28,11 +28,12 @@ export function useClipboard({ navigator = defaultNavigator }: ConfigurableNavig
   }
 
   async function copy(txt: string) {
-    text.value = txt
-
-    if (isSupported)
+    if (isSupported) {
       // @ts-expect-error untyped API
-      await navigator.clipboard.writeText(txt)
+      await navigator.clipboard.writeText(txt).then(() => {
+        text.value = txt
+      })
+    }
   }
 
   return {


### PR DESCRIPTION
- fix(useClipboard): set clipboard text only if successful

仅在复制成功时更新剪贴板的内容（如果当前页面无焦点会抛异常 `Uncaught DOMException: Document is not focused.`）