### PR TITLE
docs(useGeolocation): fix outputted coords

### DIFF
--- a/packages/core/useGeolocation/index.stories.tsx
+++ b/packages/core/useGeolocation/index.stories.tsx
@@ -17,7 +17,15 @@ defineDemo(
     template: html`
       <div>
         <pre lang="json">{{JSON.stringify({
-            coords,
+            coords: {
+              accuracy: coords.accuracy,
+              latitude: coords.latitude,
+              longitude: coords.longitude,
+              altitude: coords.altitude,
+              altitudeAccuracy: coords.altitudeAccuracy,
+              heading: coords.heading,
+              speed: coords.speed,
+            },
             locatedAt,
             error: error ? error.message : error,
           }, null, 2)}}


### PR DESCRIPTION
- docs(useGeolocation): fix outputted coords

`GeolocationCoordinates` 无法直接序列化为 JSON