### PR TITLE
refactor(useManualRefHistory)!: optimization, snapshots are no longer reactive

### DIFF
--- a/packages/core/useManualRefHistory/index.test.ts
+++ b/packages/core/useManualRefHistory/index.test.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue-demi'
+import { ref, isReactive } from 'vue-demi'
 import { useManualRefHistory } from '.'
 import { renderHook } from '../../_tests'
 
@@ -169,5 +169,19 @@ describe('useManualRefHistory', () => {
       expect(redoStack.value.length).toBe(1)
       expect(redoStack.value[0].snapshot).toBe(3)
     })
+  })
+
+  test('snapshots should not be reactive', async() => {
+    const v = ref(0)
+    const { history, commit } = useManualRefHistory(v)
+
+    expect(history.value.length).toBe(1)
+    expect(history.value[0].snapshot).toBe(0)
+
+    v.value = 2
+    commit()
+
+    expect(isReactive(history.value[0])).toBe(false)
+    expect(isReactive(history.value[1])).toBe(false)
   })
 })

--- a/packages/core/useManualRefHistory/index.ts
+++ b/packages/core/useManualRefHistory/index.ts
@@ -1,5 +1,5 @@
 import { timestamp } from '@vueuse/shared'
-import { ref, computed, Ref } from 'vue-demi'
+import { ref, computed, Ref, markRaw } from 'vue-demi'
 
 export interface UseRefHistoryRecord<T> {
   snapshot: T
@@ -119,10 +119,10 @@ export function useManualRefHistory<Raw, Serialized = Raw>(
   } = options
 
   function _createHistoryRecord(): UseRefHistoryRecord<Serialized> {
-    return {
+    return markRaw({
       snapshot: dump(source.value),
       timestamp: timestamp(),
-    }
+    })
   }
 
   const last: Ref<UseRefHistoryRecord<Serialized>> = ref(_createHistoryRecord()) as Ref<UseRefHistoryRecord<Serialized>>


### PR DESCRIPTION
I have been using `dump: JSON.stringify`, `parse: JSON.parse` so I did not think about this before. 

When the ref holds a big object and `dump: clone` is used, there could be a performant hit because of making the snapshots reactive (since they are added to the stacks refs)

This PR uses `markRaw` when creating new snapshots as an optimization. It affects both useManualRefHistory and useRefHistory. It is a breaking change but I do not think it could affect anyone (since nobody should be modifying the snapshots and watching for that changes). history, last, undoStack, redoStack remain reactive, users can watch them, but each snapshot is not tracked.

I thought about using `readonly`, but looks like it is not part of vue-demi. I also do not know if there is any perf hit by using readonly. For the moment, I think `markRaw` is ok. 