### PR TITLE
test: add basic asyncComputed tests

### DIFF
--- a/packages/core/asyncComputed/index.test.ts
+++ b/packages/core/asyncComputed/index.test.ts
@@ -22,66 +22,75 @@ describe('asyncComputed', () => {
   test('it is not lazy', async() => {
     const func = jest.fn(() => Promise.resolve('data'))
 
-    const data = asyncComputed(func)
+    const instance = renderHook(() => {
+      const data = asyncComputed(func)
+      return { data }
+    }).vm
 
     expect(func).toBeCalledTimes(1)
 
-    expect(data.value).toBeUndefined()
+    expect(instance.data).toBeUndefined()
 
     await nextTick()
     await nextTick()
 
-    expect(data.value).toBe('data')
+    expect(instance.data).toBe('data')
   })
 
   test('re-computes when dependency changes', async() => {
-    const counter = ref(1)
-    const double = asyncComputed(() => {
-      const result = counter.value * 2
-      return Promise.resolve(result)
-    })
+    const instance = renderHook(() => {
+      const counter = ref(1)
+      const double = asyncComputed(() => {
+        const result = counter.value * 2
+        return Promise.resolve(result)
+      })
+      return { counter, double }
+    }).vm
 
-    expect(double.value).toBeUndefined()
-
-    await nextTick()
-    await nextTick()
-
-    expect(double.value).toBe(2)
-
-    counter.value = 2
-    expect(double.value).toBe(2)
+    expect(instance.double).toBeUndefined()
 
     await nextTick()
     await nextTick()
 
-    expect(double.value).toBe(4)
+    expect(instance.double).toBe(2)
+
+    instance.counter = 2
+    expect(instance.double).toBe(2)
+
+    await nextTick()
+    await nextTick()
+
+    expect(instance.double).toBe(4)
   })
 
   test('triggers', async() => {
-    const counter = ref(1)
-    const double = asyncComputed(() => {
-      const result = counter.value * 2
-      return Promise.resolve(result)
-    })
-    const other = computed(() => {
-      return double.value + 1
-    })
+    const instance = renderHook(() => {
+      const counter = ref(1)
+      const double = asyncComputed(() => {
+        const result = counter.value * 2
+        return Promise.resolve(result)
+      })
+      const other = computed(() => {
+        return double.value + 1
+      })
+      return { counter, double, other }
+    }).vm
 
-    expect(double.value).toBeUndefined()
-
-    await nextTick()
-    await nextTick()
-
-    expect(double.value).toBe(2)
-
-    counter.value = 2
-    expect(double.value).toBe(2)
-    expect(other.value).toBe(3)
+    expect(instance.double).toBeUndefined()
 
     await nextTick()
     await nextTick()
 
-    expect(double.value).toBe(4)
-    expect(other.value).toBe(5)
+    expect(instance.double).toBe(2)
+
+    instance.counter = 2
+    expect(instance.double).toBe(2)
+    expect(instance.other).toBe(3)
+
+    await nextTick()
+    await nextTick()
+
+    expect(instance.double).toBe(4)
+    expect(instance.other).toBe(5)
   })
 })

--- a/packages/core/asyncComputed/index.test.ts
+++ b/packages/core/asyncComputed/index.test.ts
@@ -29,6 +29,7 @@ describe('asyncComputed', () => {
     expect(data.value).toBeUndefined()
 
     await nextTick()
+    await nextTick()
 
     expect(data.value).toBe('data')
   })
@@ -43,12 +44,14 @@ describe('asyncComputed', () => {
     expect(double.value).toBeUndefined()
 
     await nextTick()
+    await nextTick()
 
     expect(double.value).toBe(2)
 
     counter.value = 2
     expect(double.value).toBe(2)
 
+    await nextTick()
     await nextTick()
 
     expect(double.value).toBe(4)
@@ -67,6 +70,7 @@ describe('asyncComputed', () => {
     expect(double.value).toBeUndefined()
 
     await nextTick()
+    await nextTick()
 
     expect(double.value).toBe(2)
 
@@ -74,6 +78,7 @@ describe('asyncComputed', () => {
     expect(double.value).toBe(2)
     expect(other.value).toBe(3)
 
+    await nextTick()
     await nextTick()
 
     expect(double.value).toBe(4)

--- a/packages/core/asyncComputed/index.test.ts
+++ b/packages/core/asyncComputed/index.test.ts
@@ -1,0 +1,82 @@
+import { ref, computed, nextTick } from 'vue-demi'
+import { renderHook } from '../../_tests'
+import { asyncComputed } from '.'
+
+describe('computed', () => {
+  it('is lazy', async() => {
+    const func = jest.fn(() => 'data')
+
+    renderHook(() => {
+      const data = computed(func)
+
+      expect(func).not.toBeCalled()
+
+      expect(data.value).toBe('data')
+
+      expect(func).toBeCalledTimes(1)
+    })
+  })
+})
+
+describe('asyncComputed', () => {
+  test('it is not lazy', async() => {
+    const func = jest.fn(() => Promise.resolve('data'))
+
+    const data = asyncComputed(func)
+
+    expect(func).toBeCalledTimes(1)
+
+    expect(data.value).toBeUndefined()
+
+    await nextTick()
+
+    expect(data.value).toBe('data')
+  })
+
+  test('re-computes when dependency changes', async() => {
+    const counter = ref(1)
+    const double = asyncComputed(() => {
+      const result = counter.value * 2
+      return Promise.resolve(result)
+    })
+
+    expect(double.value).toBeUndefined()
+
+    await nextTick()
+
+    expect(double.value).toBe(2)
+
+    counter.value = 2
+    expect(double.value).toBe(2)
+
+    await nextTick()
+
+    expect(double.value).toBe(4)
+  })
+
+  test('triggers', async() => {
+    const counter = ref(1)
+    const double = asyncComputed(() => {
+      const result = counter.value * 2
+      return Promise.resolve(result)
+    })
+    const other = computed(() => {
+      return double.value + 1
+    })
+
+    expect(double.value).toBeUndefined()
+
+    await nextTick()
+
+    expect(double.value).toBe(2)
+
+    counter.value = 2
+    expect(double.value).toBe(2)
+    expect(other.value).toBe(3)
+
+    await nextTick()
+
+    expect(double.value).toBe(4)
+    expect(other.value).toBe(5)
+  })
+})


### PR DESCRIPTION
Some tests for `asyncComputed` that I used while checking https://github.com/antfu/vueuse/issues/248
The first two are modified versions of the ones included in https://github.com/antfu/vueuse/pull/247, checking that the callback is called immediately and not lazily.