### PR TITLE
fix(useRefHistory): cloning when undoing

### DIFF
--- a/packages/core/useManualRefHistory/index.md
+++ b/packages/core/useManualRefHistory/index.md
@@ -31,7 +31,7 @@ console.log(counter.value) // 0
 
 #### History of mutable objects
 
-If you are going to mutate the source, you need to pass a custom clone function or use the `clone` param, that is a shortcut for a minimal clone function `x => JSON.parse(JSON.stringify(x))`.
+If you are going to mutate the source, you need to pass a custom clone function or use `clone` `true` as a param, that is a shortcut for a minimal clone function `x => JSON.parse(JSON.stringify(x))` that will be used in both `dump` and `parse`.
 
 ```ts {5}
 import { ref } from 'vue' 
@@ -54,7 +54,7 @@ For example, using [lodash's `cloneDeep`](https://lodash.com/docs/4.17.15#cloneD
 import { cloneDeep } from 'lodash-es'
 import { useManualRefHistory } from '@vueuse/core'
 
-const refHistory = useManualRefHistory(target, { dump: cloneDeep })
+const refHistory = useManualRefHistory(target, { clone: cloneDeep })
 ```
 
 Or a more lightweight [`klona`](https://github.com/lukeed/klona):
@@ -63,7 +63,20 @@ Or a more lightweight [`klona`](https://github.com/lukeed/klona):
 import { klona } from 'klona'
 import { useManualRefHistory } from '@vueuse/core'
 
-const refHistory = useManualRefHistory(target, { dump: klona })
+const refHistory = useManualRefHistory(target, { clone: klona })
+```
+
+#### Custom Dump and Parse Function
+
+Instead of using the `clone` param, you can pass custom functions to control the serialization and parsing. In case you do not need history values to be objects, this can save an extra clone when undoing. It is also useful in case you want to have the snapshots already stringified to be saved to local storage for example.
+
+```ts
+import { useManualRefHistory } from '@vueuse/core'
+
+const refHistory = useManualRefHistory(target, { 
+  dump: JSON.stringify,
+  parse: JSON.parse
+})
 ```
 
 ### History Capacity

--- a/packages/core/useManualRefHistory/index.test.ts
+++ b/packages/core/useManualRefHistory/index.test.ts
@@ -71,10 +71,10 @@ describe('useManualRefHistory', () => {
     })
   })
 
-  test('sync: object with deep', () => {
+  test('object with deep', () => {
     useSetup(() => {
       const v = ref({ foo: 'bar' })
-      const { commit, history } = useManualRefHistory(v, { clone: true })
+      const { commit, undo, history } = useManualRefHistory(v, { clone: true })
 
       expect(history.value.length).toBe(1)
       expect(history.value[0].snapshot.foo).toBe('bar')
@@ -88,6 +88,36 @@ describe('useManualRefHistory', () => {
       // different references
       expect(history.value[1].snapshot.foo).toBe('bar')
       expect(history.value[0].snapshot).not.toBe(history.value[1].snapshot)
+
+      undo()
+
+      // history references should not be equal to the source
+      expect(history.value[0].snapshot).not.toBe(v.value)
+    })
+  })
+
+  test('object with clone function', () => {
+    useSetup(() => {
+      const v = ref({ foo: 'bar' })
+      const { commit, undo, history } = useManualRefHistory(v, { clone: x => JSON.parse(JSON.stringify(x)) })
+
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].snapshot.foo).toBe('bar')
+
+      v.value.foo = 'foo'
+      commit()
+
+      expect(history.value.length).toBe(2)
+      expect(history.value[0].snapshot.foo).toBe('foo')
+
+      // different references
+      expect(history.value[1].snapshot.foo).toBe('bar')
+      expect(history.value[0].snapshot).not.toBe(history.value[1].snapshot)
+
+      undo()
+
+      // history references should not be equal to the source
+      expect(history.value[0].snapshot).not.toBe(v.value)
     })
   })
 

--- a/packages/core/useRefHistory/index.md
+++ b/packages/core/useRefHistory/index.md
@@ -79,6 +79,19 @@ import { useRefHistory } from '@vueuse/core'
 const refHistory = useRefHistory(target, { dump: klona })
 ```
 
+#### Custom Dump and Parse Function
+
+Instead of using the `clone` param, you can pass custom functions to control the serialization and parsing. In case you do not need history values to be objects, this can save an extra clone when undoing. It is also useful in case you want to have the snapshots already stringified to be saved to local storage for example.
+
+```ts
+import { useRefHistory } from '@vueuse/core'
+
+const refHistory = useRefHistory(target, { 
+  dump: JSON.stringify,
+  parse: JSON.parse
+})
+```
+
 ### History Capacity
 
 We will keep all the history by default (unlimited) until you explicitly clear them up, you can set the maximal amount of history to be kept by `capacity` options.

--- a/packages/core/useRefHistory/index.test.ts
+++ b/packages/core/useRefHistory/index.test.ts
@@ -70,7 +70,7 @@ describe('useRefHistory - sync', () => {
   test('sync: object with deep', () => {
     useSetup(() => {
       const v = ref({ foo: 'bar' })
-      const { history } = useRefHistory(v, { flush: 'sync', deep: true })
+      const { history, undo } = useRefHistory(v, { flush: 'sync', deep: true })
 
       expect(history.value.length).toBe(1)
       expect(history.value[0].snapshot.foo).toBe('bar')
@@ -83,6 +83,40 @@ describe('useRefHistory - sync', () => {
       // different references
       expect(history.value[1].snapshot.foo).toBe('bar')
       expect(history.value[0].snapshot).not.toBe(history.value[1].snapshot)
+
+      undo()
+
+      // history references should not be equal to the source
+      expect(history.value[0].snapshot).not.toBe(v.value)
+    })
+  })
+
+  test('sync: shallow watch with clone', () => {
+    useSetup(() => {
+      const v = ref({ foo: 'bar' })
+      const { history, undo } = useRefHistory(v, { flush: 'sync', clone: true })
+
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].snapshot.foo).toBe('bar')
+
+      v.value.foo = 'foo'
+
+      expect(history.value.length).toBe(1)
+      expect(history.value[0].snapshot.foo).toBe('bar')
+
+      v.value = { foo: 'foo' }
+
+      expect(history.value.length).toBe(2)
+      expect(history.value[0].snapshot.foo).toBe('foo')
+
+      // different references
+      expect(history.value[1].snapshot.foo).toBe('bar')
+      expect(history.value[0].snapshot).not.toBe(history.value[1].snapshot)
+
+      undo()
+
+      // history references should not be equal to the source
+      expect(history.value[0].snapshot).not.toBe(v.value)
     })
   })
 

--- a/packages/core/useRefHistory/index.ts
+++ b/packages/core/useRefHistory/index.ts
@@ -1,5 +1,5 @@
 import { Fn, pausableFilter, ignorableWatch } from '@vueuse/shared'
-import { useManualRefHistory, UseRefHistoryRecord } from '../useManualRefHistory'
+import { useManualRefHistory, UseRefHistoryRecord, CloneFn } from '../useManualRefHistory'
 import { Ref } from 'vue-demi'
 
 export interface UseRefHistoryOptions<Raw, Serialized = Raw> {
@@ -28,11 +28,18 @@ export interface UseRefHistoryOptions<Raw, Serialized = Raw> {
   capacity?: number
 
   /**
-   * Serialize data into the histry
+   * Clone when taking a snapshot, shortcut for dump: JSON.parse(JSON.stringify(value)).
+   * Default to false
+   *
+   * @default false
+   */
+  clone?: boolean | CloneFn<Raw>
+  /**
+   * Serialize data into the history
    */
   dump?: (v: Raw) => Serialized
   /**
-   * Deserialize data from the histry
+   * Deserialize data from the history
    */
   parse?: (v: Serialized) => Raw
 }
@@ -160,7 +167,7 @@ export function useRefHistory<Raw, Serialized = Raw>(
     })
   }
 
-  const manualHistory = useManualRefHistory(source, { ...options, clone: deep, setSource })
+  const manualHistory = useManualRefHistory(source, { ...options, clone: options.clone || deep, setSource })
 
   const { clear, commit: manualCommit } = manualHistory
 


### PR DESCRIPTION
When using `clone: true` (or `deep: true`) and undoing, the same reference in `last` was assigned to the source because the parse function was a bypass. If the user mutates the source, the history was also mutated.

This PR uses clone for parse in that case fixing the issue. It also allows the user to specify the clone function directly in the clone param, so there is no need to repeat it like `{ dump: clone, parse: clone }`. So the `clone` param is now a boolean | CloneFn
The clone param is now also exposed in useRefHistory. Having a shallow watch + clone is now also possible.

Also, awesome work with vue-demi-switch @antfu! :tada: 