### PR TITLE
chore: fix docs scrollbars

### DIFF
--- a/packages/.vitepress/theme/styles/code.css
+++ b/packages/.vitepress/theme/styles/code.css
@@ -86,6 +86,7 @@ li > div[class*='language-'] {
   font-family: var(--code-font-family);
   font-size: var(--code-font-size);
   user-select: none;
+  overflow: hidden;
 }
 
 .highlight-lines .highlighted {

--- a/packages/.vitepress/theme/styles/layout.css
+++ b/packages/.vitepress/theme/styles/layout.css
@@ -47,6 +47,7 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 main {

--- a/packages/.vitepress/theme/styles/layout.css
+++ b/packages/.vitepress/theme/styles/layout.css
@@ -4,6 +4,27 @@
   box-sizing: border-box;
 }
 
+* {
+  scrollbar-color: var(--c-divider-light) var(--c-bg);
+}
+::-webkit-scrollbar {
+  width: 6px;
+}
+::-webkit-scrollbar:horizontal {
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: var(--c-bg);
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--c-divider-light);
+  border-radius: 10px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--c-divider-dark);
+}
+
 html {
   line-height: 1.4;
   font-size: 16px;


### PR DESCRIPTION
![scrollbars](https://user-images.githubusercontent.com/583075/103585398-49f0e980-4ee3-11eb-9124-e66fa2c16e07.JPG)

1. style scrollbars for browsers that are not as nice as safari (maybe the non-hover color could be more prominent)
2. hide scrollbars in the code line highlight overlay (this is a bug in vitepress default theme)
3. there was a horizontal scrollbar in the body that I couldn't fix, but I think it is safe to just hide it.

![scrollbars-after](https://user-images.githubusercontent.com/583075/103585412-4e1d0700-4ee3-11eb-9313-f8c223e0efc9.JPG)