### PR TITLE
chore: fix typo

### DIFF
--- a/packages/index.md
+++ b/packages/index.md
@@ -18,7 +18,7 @@ features:
   - title: ☁️ No bundler required
     details: Usable via CDN
   - title: 🎛 Feature Rich
-    details: 90+ functions for you to choose
+    details: 90+ functions for you to choose from
   - title: 🔋 SSR Friendly
     details: Works perfectly with Serve-side rendering / generation
   - title: 🎪 Interactive demos

--- a/packages/index.md
+++ b/packages/index.md
@@ -18,7 +18,7 @@ features:
   - title: ☁️ No bundler required
     details: Usable via CDN
   - title: 🎛 Feature Rich
-    details: 90+ functions for you to choice
+    details: 90+ functions for you to choose
   - title: 🔋 SSR Friendly
     details: Works perfectly with Serve-side rendering / generation
   - title: 🎪 Interactive demos


### PR DESCRIPTION
Fixes a small typo.

![image](https://user-images.githubusercontent.com/46059092/104104629-a1a7a000-52a9-11eb-9c83-6642262bb429.png)
